### PR TITLE
Added target "make testing" to run unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,19 @@
-# Copyright 2017 Intel Corporation. 
+# Copyright 2017 Intel Corporation.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
 PATH_TO_MK = mk
 SUBDIRS = test examples
 DOC_TARGETS = flow rules packet
+TESTING_TARGETS = packet rules
 
 all: $(SUBDIRS)
+
+.PHONY: testing
+testing: $(TESTING_TARGETS)
+	for dir in $(TESTING_TARGETS); do \
+		$(MAKE) -C $$dir $@; \
+	done
 
 .PHONY: doc
 doc: $(DOC_TARGETS)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Use **make doc** to generate full documentation. Alternatively, you can run comm
 * http://localhost:6060/pkg/yanff/packet/
 
 ### Tests
-In addition to building tests, **make** command on the top level also builds the testing framework and examples. YANFF distributed tests are packed inside of Docker container images.
+In addition to building tests, **make** command on the top level also builds the testing framework and examples. YANFF distributed tests are packed inside of Docker container images. There are also unit non-distributed tests in some packages which may be run using **make testing** command.
 
 ### Docker images
 To create Docker images on the local default target (either default UNIX socket in /var/run/docker.sock or whatever is defined in DOCKER_HOST variable) use **make images**.

--- a/packet/Makefile
+++ b/packet/Makefile
@@ -1,0 +1,7 @@
+# Copyright 2017 Intel Corporation.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+.PHONY: testing
+testing:
+	go test

--- a/rules/Makefile
+++ b/rules/Makefile
@@ -1,0 +1,7 @@
+# Copyright 2017 Intel Corporation.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+.PHONY: testing
+testing:
+	go test


### PR DESCRIPTION
New target for unit tests is separate from just building everything because to run tests it is necessary to become root while compilation may be done by a normal user.