### PR TITLE
Add more control of the system parameters for developers

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -7,6 +7,8 @@
 package common
 
 import (
+	"encoding/json"
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -69,4 +71,107 @@ func GetDPDKLogLevel() string {
 	default:
 		return "8"
 	}
+}
+
+// System config representatioin.
+type options struct {
+	CPUCoresNumber struct {
+		Value  uint `json:"value"`
+		Locked bool `json:"locked"`
+	} `json:"cores"`
+	SchedulerOff struct {
+		Value  bool `json:"value"`
+		Locked bool `json:"locked"`
+	} `json:"no-scheduler"`
+	SchedulerOffRemove struct {
+		Value  bool `json:"value"`
+		Locked bool `json:"locked"`
+	} `json:"no-remove-clones"`
+	StopDedicatedCore struct {
+		Value  bool `json:"value"`
+		Locked bool `json:"locked"`
+	} `json:"stop-at-dedicated-core"`
+	MempoolSize struct {
+		Value  uint `json:"value"`
+		Locked bool `json:"locked"`
+	} `json:"mempool-size"`
+	MbufCacheSize struct {
+		Value  uint `json:"value"`
+		Locked bool `json:"locked"`
+	} `json:"mempool-cache"`
+	SizeMultiplier struct {
+		Value  uint `json:"value"`
+		Locked bool `json:"locked"`
+	} `json:"ring-size"`
+	SchedTime struct {
+		Value  uint `json:"value"`
+		Locked bool `json:"locked"`
+	} `json:"scale-time"`
+	BurstSize struct {
+		Value  uint `json:"value"`
+		Locked bool `json:"locked"`
+	} `json:"burst-size"`
+}
+
+var OptsSettings options
+
+func DeclareFlags(optsJson []byte) {
+	// This is YANFF flags default values. By default all values
+	// are not locked and can be changes by user.
+	OptsSettings.CPUCoresNumber.Value = 8
+	OptsSettings.SchedulerOff.Value = false
+	OptsSettings.SchedulerOffRemove.Value = false
+	OptsSettings.StopDedicatedCore.Value = false
+	OptsSettings.MempoolSize.Value = 8191
+	OptsSettings.MbufCacheSize.Value = 250
+	OptsSettings.BurstSize.Value = 32
+	OptsSettings.SizeMultiplier.Value = 256
+	OptsSettings.SchedTime.Value = 1500
+
+	err := json.Unmarshal(optsJson, &OptsSettings)
+	if err != nil {
+		LogError(Debug, "JSON error during config line parsing: ", err)
+	}
+
+	// Create YANFF flags, if value is not locked by user.
+	if !OptsSettings.CPUCoresNumber.Locked {
+		flag.UintVar(&OptsSettings.CPUCoresNumber.Value, "cores", OptsSettings.CPUCoresNumber.Value, "Number of CPU cores used by system")
+	}
+	if !OptsSettings.SchedulerOff.Locked {
+		flag.BoolVar(&OptsSettings.SchedulerOff.Value, "no-scheduler", OptsSettings.SchedulerOff.Value, "Use this for switching scheduler off")
+	}
+	if !OptsSettings.SchedulerOffRemove.Locked {
+		flag.BoolVar(&OptsSettings.SchedulerOffRemove.Value, "no-remove-clones", OptsSettings.SchedulerOffRemove.Value, "Use this for switching off removing clones in scheduler")
+	}
+	if !OptsSettings.StopDedicatedCore.Locked {
+		flag.BoolVar(&OptsSettings.StopDedicatedCore.Value, "stop-at-dedicated-core", OptsSettings.StopDedicatedCore.Value, "Use this for setting scheduler and stop functionality to different cores")
+	}
+	if !OptsSettings.MempoolSize.Locked {
+		flag.UintVar(&OptsSettings.MempoolSize.Value, "mempool-size", OptsSettings.MempoolSize.Value, "Advanced option: number of mbufs in mempool per port")
+	}
+	if !OptsSettings.MbufCacheSize.Locked {
+		flag.UintVar(&OptsSettings.MbufCacheSize.Value, "mempool-cache", OptsSettings.MbufCacheSize.Value, "Advanced option: Size of local per-core cache in mempool (in mbufs)")
+	}
+	if !OptsSettings.SizeMultiplier.Locked {
+		flag.UintVar(&OptsSettings.SizeMultiplier.Value, "ring-size", OptsSettings.SizeMultiplier.Value, "Advanced option: number of 'burst_size' groups in all rings. This should be power of 2")
+	}
+	if !OptsSettings.SchedTime.Locked {
+		flag.UintVar(&OptsSettings.SchedTime.Value, "scale-time", OptsSettings.SchedTime.Value, "Time between scheduler actions in miliseconds")
+	}
+	if !OptsSettings.BurstSize.Locked {
+		flag.UintVar(&OptsSettings.BurstSize.Value, "burst-size", OptsSettings.BurstSize.Value, "Advanced option: number of mbufs per one enqueue / dequeue from ring")
+	}
+}
+
+func LogOptions(opts options) {
+	LogDebug(Debug, "------------***-------- YANFF settings --------***------------")
+	LogDebug(Debug, "CPUCoresNumber=", opts.CPUCoresNumber)
+	LogDebug(Debug, "schedulerOff=", opts.SchedulerOff)
+	LogDebug(Debug, "schedulerOffRemove=", opts.SchedulerOffRemove)
+	LogDebug(Debug, "stopDedicatedCore=", opts.StopDedicatedCore)
+	LogDebug(Debug, "mbufNumber=", opts.MempoolSize)
+	LogDebug(Debug, "mbufCacheSize=", opts.MbufCacheSize)
+	LogDebug(Debug, "sizeMultiplier=", opts.SizeMultiplier)
+	LogDebug(Debug, "schedTime=", opts.SchedTime)
+	LogDebug(Debug, "burstSize=", opts.BurstSize)
 }

--- a/examples/Firewall.go
+++ b/examples/Firewall.go
@@ -5,20 +5,18 @@
 package main
 
 import (
-	"flag"
 	"github.com/intel-go/yanff/flow"
 	"github.com/intel-go/yanff/packet"
 	"github.com/intel-go/yanff/rules"
 )
 
 var L3Rules *rules.L3Rules
+var options = `{"cores": {"Value": 8, "Locked": false}}`
 
 // Main function for constructing packet processing graph.
 func main() {
-	// Initialize YANFF library at requested number of cores
-	var cores uint
-	flag.UintVar(&cores, "cores", 8, "Number of cores to use by system")
-	flow.SystemInit(cores)
+	// Initialize YANFF library at requested number of cores.
+	flow.SystemInit(options)
 
 	// Get filtering rules from access control file.
 	L3Rules = rules.GetL3RulesFromORIG("Firewall.conf")

--- a/examples/Forwarding.go
+++ b/examples/Forwarding.go
@@ -5,20 +5,18 @@
 package main
 
 import (
-	"flag"
 	"github.com/intel-go/yanff/flow"
 	"github.com/intel-go/yanff/packet"
 	"github.com/intel-go/yanff/rules"
 )
 
 var L3Rules *rules.L3Rules
+var options = `{"cores": {"Value": 16, "Locked": false}}`
 
 // Main function for constructing packet processing graph.
 func main() {
-	// Initialize YANFF library at requested number of cores
-	var cores uint
-	flag.UintVar(&cores, "cores", 16, "Number of cores to use by system")
-	flow.SystemInit(cores)
+	// Initialize YANFF library at requested number of cores.
+	flow.SystemInit(options)
 
 	// Get splitting rules from access control file.
 	L3Rules = rules.GetL3RulesFromORIG("Forwarding.conf")

--- a/examples/demo.go
+++ b/examples/demo.go
@@ -14,14 +14,13 @@ import "time"
 var L2Rules *rules.L2Rules
 var L3Rules *rules.L3Rules
 var load uint
-var cores uint
+var options = `{"cores": {"Value": 16, "Locked": false}}`
 
 func main() {
 	flag.UintVar(&load, "load", 1000, "Use this for regulating 'load intensity', number of iterations")
-	flag.UintVar(&cores, "cores", 16, "Number of cores to use by system")
 
 	// Initialize YANFF library at requested number of cores
-	flow.SystemInit(cores)
+	flow.SystemInit(options)
 
 	// Start regular updating forwarding rules
 	L2Rules = rules.GetL2RulesFromJSON("demoL2_ACL.json")

--- a/examples/dump.go
+++ b/examples/dump.go
@@ -11,12 +11,13 @@ import (
 	"github.com/intel-go/yanff/packet"
 )
 
+var options = `{"cores": {"Value": 10, "Locked": false}}`
+
 func main() {
 	hexdumpOn := flag.Bool("hex", false, "enable dumping of packets in hex format")
-	flag.Parse()
 
-	// Initialize YANFF library at 10 available cores
-	flow.SystemInit(10)
+	// Initialize YANFF library at requested number of cores.
+	flow.SystemInit(options)
 
 	// Receive packets from zero port. One queue will be added automatically.
 	firstFlow := flow.SetReceiver(0)

--- a/test/main/latency.json
+++ b/test/main/latency.json
@@ -46,7 +46,7 @@
                     "image-name": "yanff-performance",
                     "app-type": "TESTAPP_GO",
                     "exec-cmd": [
-                        "./latency-part1"
+                        "./latency-part1", "-PASSED_LIMIT=84"
                     ]
                 },
                 {

--- a/test/performance/latency/latency-part1.go
+++ b/test/performance/latency/latency-part1.go
@@ -64,6 +64,8 @@ var (
 	latenciesStorage []time.Duration
 )
 
+var options = `{"cores": {"Value": 16, "Locked": false}}`
+
 func main() {
 	flag.IntVar(&LAT_NUMBER, "LAT_NUMBER", LAT_NUMBER, "number of packets, for which latency should be reported")
 	flag.IntVar(&BINS, "BINS", BINS, "number of bins")
@@ -82,8 +84,8 @@ func main() {
 	var m sync.Mutex
 	testDoneEvent = sync.NewCond(&m)
 
-	// Initialize YANFF library at 16 available cores
-	flow.SystemInit(16)
+	// Initialize YANFF library at requested number of cores
+	flow.SystemInit(options)
 	payloadSize = PACKET_SIZE - SERV_DATA_SIZE
 
 	// Create packet flow

--- a/test/performance/latency/latency-stub.go
+++ b/test/performance/latency/latency-stub.go
@@ -8,10 +8,12 @@ import (
 	"github.com/intel-go/yanff/flow"
 )
 
+var options = `{"cores": {"Value": 16, "Locked": false}}`
+
 // Main function for constructing packet processing graph.
 func main() {
-	// Initialize YANFF library at 16 available cores.
-	flow.SystemInit(16)
+	// Initialize YANFF library at requested number of cores.
+	flow.SystemInit(options)
 
 	// Receive packets from 0 port and send to 1 port.
 	flow1 := flow.SetReceiver(0)

--- a/test/performance/perf_light.go
+++ b/test/performance/perf_light.go
@@ -11,13 +11,13 @@ import "flag"
 
 var mode uint
 var cores uint
+var options = `{"cores": {"Value": 15, "Locked": false}}`
 
 func main() {
 	flag.UintVar(&mode, "mode", 0, "Benching mode: 0 - empty, 1 - parsing, 2 - parsing, reading, writing")
-	flag.UintVar(&cores, "cores", 15, "Number of cores to use by system")
 
 	// Initialize YANFF library at requested number of cores
-	flow.SystemInit(cores)
+	flow.SystemInit(options)
 
 	// Receive packets from zero port. One queue per receive will be added automatically.
 	firstFlow0 := flow.SetReceiver(0)

--- a/test/performance/perf_main.go
+++ b/test/performance/perf_main.go
@@ -12,14 +12,14 @@ import "flag"
 var load uint
 var loadRW uint
 var cores uint
+var options = `{"cores": {"Value": 35, "Locked": false}}`
 
 func main() {
 	flag.UintVar(&load, "load", 1000, "Use this for regulating 'load intensity', number of iterations")
 	flag.UintVar(&loadRW, "loadRW", 50, "Use this for regulating 'load read/write intensity', number of iterations")
-	flag.UintVar(&cores, "cores", 35, "Number of cores to use by system")
 
 	// Initialize YANFF library at requested number of cores
-	flow.SystemInit(cores)
+	flow.SystemInit(options)
 
 	// Receive packets from zero port. One queue per receive will be added automatically.
 	firstFlow0 := flow.SetReceiver(0)

--- a/test/performance/perf_seq.go
+++ b/test/performance/perf_seq.go
@@ -12,14 +12,14 @@ import "flag"
 var load uint
 var mode uint
 var cores uint
+var options = `{"cores": {"Value": 35, "Locked": false}}`
 
 func main() {
 	flag.UintVar(&load, "load", 1000, "Use this for regulating 'load intensity', number of iterations")
 	flag.UintVar(&mode, "mode", 2, "Benching mode: 2, 12 - two handles; 3, 13 - tree handles; 4, 14 - four handles. 2,3,4 - one flow; 12,13,14 - two flows")
-	flag.UintVar(&cores, "cores", 35, "Number of cores to use by system")
 
 	// Initialize YANFF library at requested number of cores
-	flow.SystemInit(cores)
+	flow.SystemInit(options)
 
 	var tempFlow *flow.Flow
 	var afterFlow *flow.Flow

--- a/test/stability/test1/part1.go
+++ b/test/stability/test1/part1.go
@@ -20,6 +20,7 @@ const (
 	// With average speed of 1 million packets/s the test runs for
 	// about 10 seconds
 	TOTAL_PACKETS = 100000000
+	options       = `{"cores": {"Value": 16, "Locked": false}}`
 )
 
 var (
@@ -42,7 +43,7 @@ var (
 // number of packets is received.
 func main() {
 	// Init YANFF system at 16 available cores
-	flow.SystemInit(16)
+	flow.SystemInit(options)
 
 	var m sync.Mutex
 	testDoneEvent = sync.NewCond(&m)

--- a/test/stability/test1/part2.go
+++ b/test/stability/test1/part2.go
@@ -13,10 +13,12 @@ import (
 	"github.com/intel-go/yanff/test/stability/test1/common"
 )
 
+var options = `{"cores": {"Value": 16, "Locked": false}}`
+
 // Main function for constructing packet processing graph.
 func main() {
 	// Init YANFF system
-	flow.SystemInit(16)
+	flow.SystemInit(options)
 
 	// Receive packets from zero port. Receive queue will be added automatically.
 	inputFlow := flow.SetReceiver(0)

--- a/test/stability/test_handle2/test-handle2-part1.go
+++ b/test/stability/test_handle2/test-handle2-part1.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	TOTAL_PACKETS = 10000000
+	options       = `{"cores": {"Value": 16, "Locked": false}}`
 
 	// Test expects to receive 33% of packets on 0 port and 66% on 1 port
 	// Test is PASSSED, if p1 is in [LOW1;HIGH1] and p2 in [LOW2;HIGH2]
@@ -60,8 +61,8 @@ var (
 )
 
 func main() {
-	// Init YANFF system at 16 available cores
-	flow.SystemInit(16)
+	// Init YANFF system at requested number of cores.
+	flow.SystemInit(options)
 
 	var m sync.Mutex
 	testDoneEvent = sync.NewCond(&m)

--- a/test/stability/test_handle2/test-handle2-part2.go
+++ b/test/stability/test_handle2/test-handle2-part2.go
@@ -11,11 +11,12 @@ import (
 )
 
 var L3Rules *rules.L3Rules
+var options = `{"cores": {"Value": 16, "Locked": false}}`
 
 // Main function for constructing packet processing graph.
 func main() {
-	// Init YANFF system
-	flow.SystemInit(16)
+	// Init YANFF system at requested number of cores.
+	flow.SystemInit(options)
 
 	// Get splitting rules from access control file.
 	//L2Rules = rules.GetL3RulesFromORIG("test-handle2-l2rules.conf")

--- a/test/stability/test_merge/test-merge-part1.go
+++ b/test/stability/test_merge/test-merge-part1.go
@@ -28,6 +28,7 @@ import (
 
 const (
 	TOTAL_PACKETS = 10000000
+	options       = `{"cores": {"Value": 16, "Locked": false}}`
 )
 
 var (
@@ -51,8 +52,8 @@ var (
 )
 
 func main() {
-	// Init YANFF system at 16 available cores
-	flow.SystemInit(16)
+	// Init YANFF system at requested number of cores.
+	flow.SystemInit(options)
 
 	var m sync.Mutex
 	testDoneEvent = sync.NewCond(&m)

--- a/test/stability/test_merge/test-merge-part2.go
+++ b/test/stability/test_merge/test-merge-part2.go
@@ -8,10 +8,12 @@ import (
 	"github.com/intel-go/yanff/flow"
 )
 
+var options = `{"cores": {"Value": 16, "Locked": false}}`
+
 // Main function for constructing packet processing graph.
 func main() {
-	// Init YANFF system
-	flow.SystemInit(16)
+	// Init YANFF system at requested number of cores.
+	flow.SystemInit(options)
 
 	// Receive packets from 0 and 1 ports
 	inputFlow1 := flow.SetReceiver(0)

--- a/test/stability/test_partition/test-partition-part1.go
+++ b/test/stability/test_partition/test-partition-part1.go
@@ -26,6 +26,7 @@ import (
 
 const (
 	TOTAL_PACKETS = 10000000
+	options       = `{"cores": {"Value": 16, "Locked": false}}`
 
 	// Test expects to receive ~90% of packets on 0 port and ~10% on 1 port
 	// Test is PASSSED, if p1 is in [LOW1;HIGH1] and p2 in [LOW2;HIGH2]
@@ -49,8 +50,8 @@ var (
 )
 
 func main() {
-	// Init YANFF system at 16 available cores
-	flow.SystemInit(16)
+	// Init YANFF system at requested number of cores.
+	flow.SystemInit(options)
 
 	var m sync.Mutex
 	testDoneEvent = sync.NewCond(&m)

--- a/test/stability/test_partition/test-partition-part2.go
+++ b/test/stability/test_partition/test-partition-part2.go
@@ -8,10 +8,12 @@ import (
 	"github.com/intel-go/yanff/flow"
 )
 
+var options = `{"cores": {"Value": 16, "Locked": false}}`
+
 // Main function for constructing packet processing graph.
 func main() {
-	// Init YANFF system
-	flow.SystemInit(16)
+	// Init YANFF system at requested number of cores.
+	flow.SystemInit(options)
 
 	// Receive packets from 0 port
 	flow1 := flow.SetReceiver(0)

--- a/test/stability/test_separate/test-separate-part1.go
+++ b/test/stability/test_separate/test-separate-part1.go
@@ -29,6 +29,7 @@ import (
 
 const (
 	TOTAL_PACKETS = 100000000
+	options       = `{"cores": {"Value": 16, "Locked": false}}`
 
 	// Test expects to receive 33% of packets on 0 port and 66% on 1 port
 	// Test is PASSSED, if p1 is in [LOW1;HIGH1] and p2 in [LOW2;HIGH2]
@@ -61,8 +62,8 @@ var (
 )
 
 func main() {
-	// Init YANFF system at 16 available cores
-	flow.SystemInit(16)
+	// Init YANFF system at requested number of cores.
+	flow.SystemInit(options)
 
 	var m sync.Mutex
 	testDoneEvent = sync.NewCond(&m)

--- a/test/stability/test_separate/test-separate-part2.go
+++ b/test/stability/test_separate/test-separate-part2.go
@@ -11,11 +11,12 @@ import (
 )
 
 var L3Rules *rules.L3Rules
+var options = `{"cores": {"Value": 16, "Locked": false}}`
 
 // Main function for constructing packet processing graph.
 func main() {
-	// Init YANFF system
-	flow.SystemInit(16)
+	// Init YANFF system at requested number of cores.
+	flow.SystemInit(options)
 
 	// Get splitting rules from access control file.
 	//L2Rules = rules.GetL3RulesFromORIG("test-separate-l2rules.conf")

--- a/test/stability/test_split/test-split-part1.go
+++ b/test/stability/test_split/test-split-part1.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	TOTAL_PACKETS = 100000000
+	options       = `{"cores": {"Value": 16, "Locked": false}}`
 
 	// Proportion of each packet group among all received packets
 	// from ports 1,2,3 should be nearly 33%.
@@ -62,8 +63,8 @@ var (
 )
 
 func main() {
-	// Init YANFF system at 16 available cores
-	flow.SystemInit(16)
+	// Init YANFF system at requested number of cores.
+	flow.SystemInit(options)
 
 	var m sync.Mutex
 	testDoneEvent = sync.NewCond(&m)

--- a/test/stability/test_split/test-split-part2.go
+++ b/test/stability/test_split/test-split-part2.go
@@ -11,11 +11,12 @@ import (
 )
 
 var L3Rules *rules.L3Rules
+var options = `{"cores": {"Value": 16, "Locked": false}}`
 
 // Main function for constructing packet processing graph.
 func main() {
-	// Init YANFF system
-	flow.SystemInit(16)
+	// Init YANFF system at requested number of cores.
+	flow.SystemInit(options)
 
 	// Get splitting rules from access control file.
 	L3Rules = rules.GetL3RulesFromORIG("test-split.conf")

--- a/test/stash/create_packet_example.go
+++ b/test/stash/create_packet_example.go
@@ -14,15 +14,24 @@ import (
 var firstFlow *flow.Flow
 var buffer []byte
 
+// New default values can be specified here.
+var optsJsonExample string = `{ "cores": {"Value": 16, "Locked": false},
+                                "no-scheduler": {"Value": true, "Locked": true},
+                                "mempool-size": {"Value": 8191, "Locked": true},
+                                "no-remove-clones": {"Value": false, "Locked": true},
+                                "ring-size": {"Value": 512, "Locked": true},
+                                "scale-time": {"Value": 1000, "Locked": false},
+                                "burst-size": {"Value": 32, "Locked": false},
+                                "mempool-cache": {"Value": 250, "Locked": false}}`
+
 func main() {
 	// By default this example generates 128-byte empty packets with
 	// InitEmptyEtherIPv4TCPPacket() and set Ethernet destination address.
 	// If flag enabled, generates packets with PacketFromByte() from raw buffer.
 	enablePacketFromByte := flag.Bool("pfb", false, "enables generating packets with PacketFromByte() from raw buffer. Otherwise, by default empty 128-byte packets are generated")
-	flag.Parse()
 
-	// Initialize YANFF library at 16 available cores
-	flow.SystemInit(16)
+	// Initialize YANFF library at requested number of cores.
+	flow.SystemInit(optsJsonExample)
 
 	// Create packets with speed at least 1000 packets/s
 	if *enablePacketFromByte == false {

--- a/test/stash/forwardingTestL3.go
+++ b/test/stash/forwardingTestL3.go
@@ -27,13 +27,14 @@ import "flag"
 // Pktgen MBits: 13743/30462         28634/29442             13743/0              1955/0           58076/59905
 
 var L3Rules *rules.L3Rules
+var options = `{"cores": {"Value": 16, "Locked": false}}`
 
 func main() {
 	var mode string
 	flag.StringVar(&mode, "mode", "orig", "Format of rules file")
 
 	// Initialize YANFF library at 16 available cores
-	flow.SystemInit(16)
+	flow.SystemInit(options)
 
 	// Start regular updating forwarding rules
 	switch mode {


### PR DESCRIPTION
Before all default values of system parameters were set in code
and then modified via cmd line options. This commit adds more control:
1. New default values can be specified by developer with JSON-formatted
string which is passed to SystemInit().
2. Default values can be locked from user change.

Flags creation and default values assignment move to common package.
Parameter CPUCoresNumber is made a field of struct OptsSettings.
Move debug print of options to package common. Update examples.