### PR TITLE
Fix setting number of cores

### DIFF
--- a/examples/Firewall.go
+++ b/examples/Firewall.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"flag"
 	"github.com/intel-go/yanff/flow"
 	"github.com/intel-go/yanff/packet"
 	"github.com/intel-go/yanff/rules"
@@ -15,10 +14,8 @@ var L3Rules *rules.L3Rules
 
 // Main function for constructing packet processing graph.
 func main() {
-	// Initialize YANFF library at requested number of cores
-	var cores uint
-	flag.UintVar(&cores, "cores", 8, "Number of cores to use by system")
-	flow.SystemInit(cores)
+	// Initialize YANFF library at 8 cores by default
+	flow.SystemInit(8)
 
 	// Get filtering rules from access control file.
 	L3Rules = rules.GetL3RulesFromORIG("Firewall.conf")

--- a/examples/Forwarding.go
+++ b/examples/Forwarding.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"flag"
 	"github.com/intel-go/yanff/flow"
 	"github.com/intel-go/yanff/packet"
 	"github.com/intel-go/yanff/rules"
@@ -15,10 +14,8 @@ var L3Rules *rules.L3Rules
 
 // Main function for constructing packet processing graph.
 func main() {
-	// Initialize YANFF library at requested number of cores
-	var cores uint
-	flag.UintVar(&cores, "cores", 16, "Number of cores to use by system")
-	flow.SystemInit(cores)
+	// Initialize YANFF library at 16 cores by default
+	flow.SystemInit(16)
 
 	// Get splitting rules from access control file.
 	L3Rules = rules.GetL3RulesFromORIG("Forwarding.conf")

--- a/examples/demo.go
+++ b/examples/demo.go
@@ -14,14 +14,12 @@ import "time"
 var L2Rules *rules.L2Rules
 var L3Rules *rules.L3Rules
 var load uint
-var cores uint
 
 func main() {
 	flag.UintVar(&load, "load", 1000, "Use this for regulating 'load intensity', number of iterations")
-	flag.UintVar(&cores, "cores", 16, "Number of cores to use by system")
 
-	// Initialize YANFF library at requested number of cores
-	flow.SystemInit(cores)
+	// Initialize YANFF library at 16 cores by default
+	flow.SystemInit(16)
 
 	// Start regular updating forwarding rules
 	L2Rules = rules.GetL2RulesFromJSON("demoL2_ACL.json")

--- a/flow/flow.go
+++ b/flow/flow.go
@@ -239,9 +239,10 @@ const (
 )
 
 // Initializing of system. This function should be always called before graph construction.
-// CPUCoresNumber is a number of cores which will be available for scheduler to place flow functions and their clones.
+// defaultCPUCoresNumber is a default number of cores which will be available for scheduler
+// to place flow functions and their clones. This number can be always changed by cores-number option.
 // Function can panic during execution.
-func SystemInit(CPUCoresNumber uint) {
+func SystemInit(defaultCPUCoresNumber uint) {
 	schedulerOff := flag.Bool("no-scheduler", false, "Use this for switching scheduler off")
 	schedulerOffRemove := flag.Bool("no-remove-clones", false, "Use this for switching off removing clones in scheduler")
 	stopDedicatedCore := flag.Bool("stop-at-dedicated-core", false, "Use this for setting scheduler and stop functionality to different cores")
@@ -251,6 +252,7 @@ func SystemInit(CPUCoresNumber uint) {
 	flag.UintVar(&schedTime, "scale-time", 1500, "Time between scheduler actions in miliseconds")
 	flag.UintVar(&burstSize, "burst-size", 32, "Advanced option: number of mbufs per one enqueue / dequeue from ring")
 	checkTime := flag.Uint("check-behaviour-time", 10000, "Time in miliseconds for scheduler to check changing of flow function behaviour")
+	CPUCoresNumber := flag.Uint("cores-number", defaultCPUCoresNumber, "Number of cores to use by system")
 	argc, argv := low.ParseFlags()
 	// We want to add new clone if input ring is approximately 80% full
 	maxPacketsToClone = uint32(sizeMultiplier * burstSize / 5 * 4)
@@ -268,7 +270,7 @@ func SystemInit(CPUCoresNumber uint) {
 	// Init scheduler
 	common.LogTitle(common.Initialization, "------------***------ Initializing scheduler -----***------------")
 	StopRing := low.CreateQueue(generateRingName(), burstSize*sizeMultiplier)
-	schedState = scheduler.NewScheduler(CPUCoresNumber, *schedulerOff, *schedulerOffRemove, *stopDedicatedCore, StopRing, *checkTime)
+	schedState = scheduler.NewScheduler(*CPUCoresNumber, *schedulerOff, *schedulerOffRemove, *stopDedicatedCore, StopRing, *checkTime)
 	common.LogTitle(common.Initialization, "------------***------ Filling FlowFunctions ------***------------")
 }
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -285,7 +285,7 @@ func (scheduler *Scheduler) getCore(startStage bool) int {
 		}
 	}
 	if startStage == true {
-		common.LogError(common.Initialization, "Requested number of cores isn't enough. System needs at least one core per each Set function (except Merger and Stop) plus two additional cores.")
+		common.LogError(common.Initialization, "Requested number of cores isn't enough. System needs at least one core per each Set function (except Merger and Stopper) plus one additional core.")
 	}
 	return -1
 }

--- a/test/performance/perf_light.go
+++ b/test/performance/perf_light.go
@@ -10,14 +10,12 @@ import "github.com/intel-go/yanff/packet"
 import "flag"
 
 var mode uint
-var cores uint
 
 func main() {
 	flag.UintVar(&mode, "mode", 0, "Benching mode: 0 - empty, 1 - parsing, 2 - parsing, reading, writing")
-	flag.UintVar(&cores, "cores", 15, "Number of cores to use by system")
 
-	// Initialize YANFF library at requested number of cores
-	flow.SystemInit(cores)
+	// Initialize YANFF library at 15 cores by default
+	flow.SystemInit(15)
 
 	// Receive packets from zero port. One queue per receive will be added automatically.
 	firstFlow0 := flow.SetReceiver(0)

--- a/test/performance/perf_main.go
+++ b/test/performance/perf_main.go
@@ -11,15 +11,13 @@ import "flag"
 
 var load uint
 var loadRW uint
-var cores uint
 
 func main() {
 	flag.UintVar(&load, "load", 1000, "Use this for regulating 'load intensity', number of iterations")
 	flag.UintVar(&loadRW, "loadRW", 50, "Use this for regulating 'load read/write intensity', number of iterations")
-	flag.UintVar(&cores, "cores", 35, "Number of cores to use by system")
 
-	// Initialize YANFF library at requested number of cores
-	flow.SystemInit(cores)
+	// Initialize YANFF library at 35 cores by default
+	flow.SystemInit(35)
 
 	// Receive packets from zero port. One queue per receive will be added automatically.
 	firstFlow0 := flow.SetReceiver(0)

--- a/test/performance/perf_seq.go
+++ b/test/performance/perf_seq.go
@@ -11,15 +11,13 @@ import "flag"
 
 var load uint
 var mode uint
-var cores uint
 
 func main() {
 	flag.UintVar(&load, "load", 1000, "Use this for regulating 'load intensity', number of iterations")
 	flag.UintVar(&mode, "mode", 2, "Benching mode: 2, 12 - two handles; 3, 13 - tree handles; 4, 14 - four handles. 2,3,4 - one flow; 12,13,14 - two flows")
-	flag.UintVar(&cores, "cores", 35, "Number of cores to use by system")
 
-	// Initialize YANFF library at requested number of cores
-	flow.SystemInit(cores)
+	// Initialize YANFF library at 35 cores by default
+	flow.SystemInit(35)
 
 	var tempFlow *flow.Flow
 	var afterFlow *flow.Flow

--- a/test/performance/sendback.go
+++ b/test/performance/sendback.go
@@ -9,17 +9,15 @@ import "github.com/intel-go/yanff/flow"
 import "flag"
 
 var inport, outport uint
-var cores uint
 
 // This is a test for pure send/receive performance measurements. No
 // other functions used here.
 func main() {
 	flag.UintVar(&inport, "inport", 0, "Input port number")
 	flag.UintVar(&outport, "outport", 0, "Output port number")
-	flag.UintVar(&cores, "cores", 16, "Number of cores to use by system")
 
-	// Initialize YANFF library at requested number of cores
-	flow.SystemInit(cores)
+	// Initialize YANFF library at 16 cores by default
+	flow.SystemInit(16)
 
 	// Receive packets from input port. One queue will be added automatically.
 	f := flow.SetReceiver(uint8(inport))


### PR DESCRIPTION
As Maria pointed user's cores option is used before flag parsing.
It is wrong. So library option "cores-number" was added.
User defined value passed to Init function is used for default
value of this option.