### PR TITLE
Storing packet structure at the beginning of the mbuf structure

### DIFF
--- a/packet/packet_test.go
+++ b/packet/packet_test.go
@@ -219,7 +219,6 @@ var pkts = [8]Packet{
 		TCP:      &TCPHeader[0],
 		UDP:      nil,
 		Unparsed: 0,
-		CMbuf:    nil,
 	},
 	{
 		Ether:    &MacHeader[1],
@@ -228,7 +227,6 @@ var pkts = [8]Packet{
 		TCP:      &TCPHeader[1],
 		UDP:      nil,
 		Unparsed: 0,
-		CMbuf:    nil,
 	},
 	{
 		Ether:    &MacHeader[2],
@@ -237,7 +235,6 @@ var pkts = [8]Packet{
 		TCP:      nil,
 		UDP:      &UDPHeader[0],
 		Unparsed: 0,
-		CMbuf:    nil,
 	},
 	{
 		Ether:    &MacHeader[3],
@@ -246,7 +243,6 @@ var pkts = [8]Packet{
 		TCP:      &TCPHeader[2],
 		UDP:      nil,
 		Unparsed: 0,
-		CMbuf:    nil,
 	},
 	{
 		Ether:    &MacHeader[4],
@@ -255,7 +251,6 @@ var pkts = [8]Packet{
 		TCP:      &TCPHeader[3],
 		UDP:      nil,
 		Unparsed: 0,
-		CMbuf:    nil,
 	},
 	{
 		Ether:    &MacHeader[5],
@@ -264,7 +259,6 @@ var pkts = [8]Packet{
 		TCP:      nil,
 		UDP:      &UDPHeader[1],
 		Unparsed: 0,
-		CMbuf:    nil,
 	},
 	{
 		Ether:    &MacHeader[6],
@@ -273,7 +267,6 @@ var pkts = [8]Packet{
 		TCP:      &TCPHeader[3],
 		UDP:      nil,
 		Unparsed: 0,
-		CMbuf:    nil,
 	},
 	{
 		Ether:    &MacHeader[7],
@@ -282,7 +275,6 @@ var pkts = [8]Packet{
 		TCP:      nil,
 		UDP:      &UDPHeader[1],
 		Unparsed: 0,
-		CMbuf:    nil,
 	},
 }
 
@@ -301,10 +293,9 @@ var lines = []string{
 func TestParseL4(t *testing.T) {
 	for i := 0; i < len(lines); i++ {
 		decoded, _ := hex.DecodeString(lines[i])
-		pkt := new(Packet)
 		mb := make([]uintptr, 1)
 		low.AllocateMbufs(mb)
-		pkt.CreatePacket(mb[0])
+		pkt := ExtractPacket(mb[0])
 		PacketFromByte(pkt, decoded)
 		if pkt == nil {
 			t.Fatal("Unable to construct mbuf")
@@ -334,10 +325,9 @@ func TestParseL4(t *testing.T) {
 func TestParseEther(t *testing.T) {
 	for i := 0; i < len(lines); i++ {
 		decoded, _ := hex.DecodeString(lines[i])
-		pkt := new(Packet)
 		mb := make([]uintptr, 1)
 		low.AllocateMbufs(mb)
-		pkt.CreatePacket(mb[0])
+		pkt := ExtractPacket(mb[0])
 		PacketFromByte(pkt, decoded)
 
 		pkt.ParseEther()
@@ -352,10 +342,9 @@ func TestParseEther(t *testing.T) {
 func TestParseEtherIPv4(t *testing.T) {
 	for i := 0; i < len(lines); i++ {
 		decoded, _ := hex.DecodeString(lines[i])
-		pkt := new(Packet)
 		mb := make([]uintptr, 1)
 		low.AllocateMbufs(mb)
-		pkt.CreatePacket(mb[0])
+		pkt := ExtractPacket(mb[0])
 		PacketFromByte(pkt, decoded)
 
 		pkt.ParseEtherIPv4()
@@ -375,10 +364,9 @@ func TestParseEtherIPv4(t *testing.T) {
 func TestParseEtherIPv4_(t *testing.T) {
 	for i := 0; i < len(lines); i++ {
 		decoded, _ := hex.DecodeString(lines[i])
-		pkt := new(Packet)
 		mb := make([]uintptr, 1)
 		low.AllocateMbufs(mb)
-		pkt.CreatePacket(mb[0])
+		pkt := ExtractPacket(mb[0])
 		PacketFromByte(pkt, decoded)
 
 		if i == 2 || i == 5 || i == 7 {
@@ -420,15 +408,13 @@ func TestParseEtherIPv4TCPDataFunctions(t *testing.T) {
 	gt_payload := uint64(12345)
 	buffer := "001122334455011121314151080045000030bffd00000406eebb7f0000018009090504d2162e123456781234569050102000621c00003930000000000000"
 	decoded, _ := hex.DecodeString(buffer)
-	pkt := new(Packet)
 	mb := make([]uintptr, 1)
 	low.AllocateMbufs(mb)
-	pkt.CreatePacket(mb[0])
+	pkt := ExtractPacket(mb[0])
 	PacketFromByte(pkt, decoded)
 
-	parsedPkt := new(Packet)
 	low.AllocateMbufs(mb)
-	parsedPkt.CreatePacket(mb[0])
+	parsedPkt := ExtractPacket(mb[0])
 	PacketFromByte(parsedPkt, decoded)
 	parsedPkt.ParseEtherIPv4TCP()
 
@@ -490,10 +476,9 @@ func TestParseIPv4UDPDataFunctions(t *testing.T) {
 	gt_payload := uint64(12345)
 	buffer := "001122334455011121314151080045000024bffd00000411eebc7f0000018009090504d2162e0010a38e393000000000000000000000000000000000"
 	decoded, _ := hex.DecodeString(buffer)
-	pkt := new(Packet)
 	mb := make([]uintptr, 1)
 	low.AllocateMbufs(mb)
-	pkt.CreatePacket(mb[0])
+	pkt := ExtractPacket(mb[0])
 	PacketFromByte(pkt, decoded)
 
 	pkt.ParseEtherIPv4UDPData()
@@ -532,15 +517,13 @@ func TestParseIPv6TCPDataFunctions(t *testing.T) {
 	gt_payload := uint64(12345)
 	buffer := "00112233445501112131415186dd60000000001c0600dead000000000000000000000000beafdead000000000000000000000000ddfd04d2162e123456781234569050102000102300003930000000000000"
 	decoded, _ := hex.DecodeString(buffer)
-	pkt := new(Packet)
 	mb := make([]uintptr, 1)
 	low.AllocateMbufs(mb)
-	pkt.CreatePacket(mb[0])
+	pkt := ExtractPacket(mb[0])
 	PacketFromByte(pkt, decoded)
 
-	parsedPkt := new(Packet)
 	low.AllocateMbufs(mb)
-	parsedPkt.CreatePacket(mb[0])
+	parsedPkt := ExtractPacket(mb[0])
 	PacketFromByte(parsedPkt, decoded)
 	parsedPkt.ParseEtherIPv6TCP()
 
@@ -594,10 +577,9 @@ func TestParseIPv6UDPDataFunctions(t *testing.T) {
 	gt_payload := uint64(12345)
 	buffer := "00112233445501112131415186dd6000000000101100dead000000000000000000000000beafdead000000000000000000000000ddfd04d2162e001051953930000000000000"
 	decoded, _ := hex.DecodeString(buffer)
-	pkt := new(Packet)
 	mb := make([]uintptr, 1)
 	low.AllocateMbufs(mb)
-	pkt.CreatePacket(mb[0])
+	pkt := ExtractPacket(mb[0])
 	PacketFromByte(pkt, decoded)
 
 	pkt.ParseEtherIPv6UDPData()
@@ -643,13 +625,12 @@ func TestEncapsulationDecapsulationFunctions(t *testing.T) {
 	init := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 	add := []byte{30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49}
 
-	pkt := new(Packet)
 	mb := make([]uintptr, 1)
 
 	for i := uint(0); i < 11; i++ {
 		for j := uint(1); j < 21; j++ {
 			low.AllocateMbufs(mb)
-			pkt.CreatePacket(mb[0])
+			pkt := ExtractPacket(mb[0])
 			PacketFromByte(pkt, init)
 
 			pkt.EncapsulateHead(i, j)
@@ -666,7 +647,7 @@ func TestEncapsulationDecapsulationFunctions(t *testing.T) {
 	for i := uint(0); i < 11; i++ {
 		for j := uint(1); j < 21; j++ {
 			low.AllocateMbufs(mb)
-			pkt.CreatePacket(mb[0])
+			pkt := ExtractPacket(mb[0])
 			PacketFromByte(pkt, init)
 
 			pkt.EncapsulateTail(i, j)
@@ -683,7 +664,7 @@ func TestEncapsulationDecapsulationFunctions(t *testing.T) {
 	for i := uint(0); i < 20; i++ {
 		for j := uint(1); j < 20-i+1; j++ {
 			low.AllocateMbufs(mb)
-			pkt.CreatePacket(mb[0])
+			pkt := ExtractPacket(mb[0])
 			PacketFromByte(pkt, add)
 
 			pkt.DecapsulateHead(i, j)
@@ -699,7 +680,7 @@ func TestEncapsulationDecapsulationFunctions(t *testing.T) {
 	for i := uint(0); i < 20; i++ {
 		for j := uint(1); j < 20-i+1; j++ {
 			low.AllocateMbufs(mb)
-			pkt.CreatePacket(mb[0])
+			pkt := ExtractPacket(mb[0])
 			PacketFromByte(pkt, add)
 
 			pkt.DecapsulateTail(i, j)

--- a/rules/rules_internal_test.go
+++ b/rules/rules_internal_test.go
@@ -56,10 +56,10 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"log"
 	"github.com/intel-go/yanff/low"
 	"github.com/intel-go/yanff/packet"
+	"io/ioutil"
+	"log"
 	"os"
 	"reflect"
 	"testing"
@@ -444,10 +444,9 @@ func TestInternal_l4_ACL_packetIPv4_TCP(t *testing.T) {
 	// TCP packet Packet 1
 	buffer := "001122334455011121314151080045000028bffd00000406eec37f0000018009090504d2162e1234567812345690501020009b540000000000000000"
 	decoded, _ := hex.DecodeString(buffer)
-	pkt := new(packet.Packet)
 	mb := make([]uintptr, 1)
 	low.AllocateMbufs(mb)
-	pkt.CreatePacket(mb[0])
+	pkt := packet.ExtractPacket(mb[0])
 	packet.PacketFromByte(pkt, decoded)
 	pkt.ParseL4()
 
@@ -507,10 +506,9 @@ func TestInternal_l3_ACL_packetIPv4_TCP(t *testing.T) {
 	// Packet 1
 	buffer := "001122334455011121314151080045000028bffd00000406eec37f0000018009090504d2162e1234567812345690501020009b540000000000000000"
 	decoded, _ := hex.DecodeString(buffer)
-	pkt := new(packet.Packet)
 	mb := make([]uintptr, 1)
 	low.AllocateMbufs(mb)
-	pkt.CreatePacket(mb[0])
+	pkt := packet.ExtractPacket(mb[0])
 	packet.PacketFromByte(pkt, decoded)
 
 	pkt.ParseL4()
@@ -572,10 +570,9 @@ func TestInternal_l3_l4_ACL_packetIPv4_TCP(t *testing.T) {
 	// Packet 1
 	buffer := "001122334455011121314151080045000028bffd00000406eec37f0000018009090504d2162e1234567812345690501020009b540000000000000000"
 	decoded, _ := hex.DecodeString(buffer)
-	pkt := new(packet.Packet)
 	mb := make([]uintptr, 1)
 	low.AllocateMbufs(mb)
-	pkt.CreatePacket(mb[0])
+	pkt := packet.ExtractPacket(mb[0])
 	packet.PacketFromByte(pkt, decoded)
 
 	pkt.ParseL4()
@@ -688,10 +685,9 @@ func TestInternal_l3_l4_ACL_packetIPv4_TCP(t *testing.T) {
 func TestInternal_l3_l4_ACL_packetIPv6_TCP(t *testing.T) {
 	buffer := "00112233445501112131415186dd6000000000140600dead000000000000000000000000beafdead000000000000000000000000ddfd04d2162e123456781234569050102000495b0000"
 	decoded, _ := hex.DecodeString(buffer)
-	pkt := new(packet.Packet)
 	mb := make([]uintptr, 1)
 	low.AllocateMbufs(mb)
-	pkt.CreatePacket(mb[0])
+	pkt := packet.ExtractPacket(mb[0])
 	packet.PacketFromByte(pkt, decoded)
 
 	pkt.ParseL4()
@@ -826,10 +822,9 @@ func TestInternal_l3_l4_ACL_packetIPv6_TCP(t *testing.T) {
 func TestInternal_l3_l4_ACL_packetIPv6_UDP(t *testing.T) {
 	buffer := "00112233445501112131415186dd6000000000081100dead000000000000000000000000beafdead000000000000000000000000ddfd04d2162e00088ad5"
 	decoded, _ := hex.DecodeString(buffer)
-	pkt := new(packet.Packet)
 	mb := make([]uintptr, 1)
 	low.AllocateMbufs(mb)
-	pkt.CreatePacket(mb[0])
+	pkt := packet.ExtractPacket(mb[0])
 	packet.PacketFromByte(pkt, decoded)
 
 	pkt.ParseL4()
@@ -952,10 +947,9 @@ func TestInternal_l2_ACL(t *testing.T) {
 	// Packet 1
 	buffer := "001122334455011121314151080045000028bffd00000406eec37f0000018009090504d2162e1234567812345690501020009b540000000000000000"
 	decoded, _ := hex.DecodeString(buffer)
-	pkt := new(packet.Packet)
 	mb := make([]uintptr, 1)
 	low.AllocateMbufs(mb)
-	pkt.CreatePacket(mb[0])
+	pkt := packet.ExtractPacket(mb[0])
 	packet.PacketFromByte(pkt, decoded)
 
 	pkt.ParseL4()


### PR DESCRIPTION
YANFF has a limitation that parsed packets are loosen after exiting flow function.
We can't save packet structure (8 pointers to protocol headers) anywhere for the
following flow function because we need some memory allocation which is slow.

However each mbuf have "headroom" before packet payload. This "headroom" is used
for fast prepending to payload, for example while encapsulation. The length of
headroom is a property of DPDK and can be changed in dpdk/config/common_base file
in CONFIG_RTE_PKTMBUF_HEADROOM. We can use some of this memory for storing
packet structure there. For this we should:

1) Clean and prepare this headroom after receiving packet
   and after allocating mbuf for generation. This required
   removing "-g" from C compiling and using of fast AVX instructions.
2) Consider size of packet structure in prepend function
3) Change CreatePacket functions that creates packets from mbuf
   to ExtractPacket functions which extracts this memory from mbuf.
   This requires changing of prefetchs, they need to prefetch
   different line.

Stability was checked, performance of no-scheduler increased for 4%, number of cores after switching scheduler on decreased for 3%.