### PR TITLE
Fix loss of starting packets in generated flow

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -250,7 +250,7 @@ func SystemInit(defaultCPUCoresNumber uint) {
 	mbufCacheSize := flag.Uint("mempool-cache", 250, "Advanced option: Size of local per-core cache in mempool (in mbufs)")
 	flag.UintVar(&sizeMultiplier, "ring-size", 256, "Advanced option: number of 'burst_size' groups in all rings. This should be power of 2")
 	flag.UintVar(&schedTime, "scale-time", 1500, "Time between scheduler actions in miliseconds")
-	flag.UintVar(&burstSize, "burst-size", 32, "Advanced option: number of mbufs per one enqueue / dequeue from ring")
+	flag.UintVar(&burstSize, "burst-size", 32, "Advanced option: number of mbufs per one enqueue / dequeue from ring. Default value is tested for performance and not recommended to change")
 	checkTime := flag.Uint("check-behaviour-time", 10000, "Time in miliseconds for scheduler to check changing of flow function behaviour")
 	CPUCoresNumber := flag.Uint("cores-number", defaultCPUCoresNumber, "Number of cores to use by system")
 	argc, argv := low.ParseFlags()
@@ -286,6 +286,12 @@ func SystemStart() {
 			low.CreatePort(createdPorts[i].port, createdPorts[i].rxQueuesNumber, createdPorts[i].txQueuesNumber)
 		}
 	}
+	// Timeout is needed for ports to start up. This way is used in pktgen.
+	// Pktgen also has checks for link status for all ports, but we compensate it
+	// by additional time.
+	// Timeout prevents loss of starting packets in generated flow.
+	time.Sleep(time.Second * 2)
+
 	common.LogTitle(common.Initialization, "------------***------ Starting FlowFunctions -----***------------")
 	schedState.SystemStart()
 	common.LogTitle(common.Initialization, "------------***--------- YANFF-GO Started --------***------------")

--- a/test/stash/Makefile
+++ b/test/stash/Makefile
@@ -4,6 +4,6 @@
 
 PATH_TO_MK = ../../mk
 IMAGENAME = yanff-stash
-EXECUTABLES = create_packet_example forwardingTestL3
+EXECUTABLES = create_packet_example forwardingTestL3 send_fixed_number
 
 include $(PATH_TO_MK)/leaf.mk

--- a/test/stash/send_fixed_number.go
+++ b/test/stash/send_fixed_number.go
@@ -1,0 +1,54 @@
+// Copyright 2017 Intel Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"flag"
+	"github.com/intel-go/yanff/flow"
+	"github.com/intel-go/yanff/packet"
+	"os"
+	"sync/atomic"
+)
+
+var TOTAL_PACKETS int64
+var PACKET_SIZE uint
+var count int64 = 0
+
+// Total packet size is 14+20+20+payload_size+4(crc)
+var payload_size uint
+var hdrs_size uint = 14 + 20 + 20 + 4
+
+func main() {
+	flag.Int64Var(&TOTAL_PACKETS, "TOTAL_PACKETS", 1234, "Number of packets to send")
+	flag.UintVar(&PACKET_SIZE, "PACKET_SIZE", 128, "Size of generated packet")
+	payload_size = PACKET_SIZE - hdrs_size
+
+	// Initialize YANFF library at 16 available cores
+	flow.SystemInit(16)
+
+	// With generateOne all packets are sent.
+	f1 := flow.SetGenerator(generatePacket, 0, nil)
+	// With generatePerf sent only multiple of burst-size.
+	// f1 := flow.SetGenerator(generatePacket, 100, nil)
+	f2 := flow.SetPartitioner(f1, 350, 350)
+
+	// Send all generated packets to the output
+	flow.SetSender(f1, 0)
+	flow.SetSender(f2, 0)
+
+	flow.SystemStart()
+}
+
+func generatePacket(pkt *packet.Packet, context flow.UserContext) {
+	sent := atomic.LoadInt64(&count)
+
+	packet.InitEmptyEtherIPv4TCPPacket(pkt, payload_size)
+	pkt.Ether.DAddr = [6]uint8{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}
+	if sent >= TOTAL_PACKETS {
+		println("Sent ", sent, "number of packets")
+		os.Exit(0)
+	}
+	atomic.AddInt64(&count, 1)
+}


### PR DESCRIPTION
Delay is needed to let ports start. This is pktgen-like solution.