### PR TITLE
Added API function to get MAC address

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -12,6 +12,46 @@ import (
 	"os"
 )
 
+// Length of addresses.
+const (
+	EtherAddrLen = 6
+	IPv6AddrLen  = 16
+)
+
+// Supported EtherType for L2
+const (
+	IPV4Number = 0x0800
+	IPV6Number = 0x86dd
+)
+
+// Supported L4 types
+const (
+	IPNumber  = 0x04
+	TCPNumber = 0x06
+	UDPNumber = 0x11
+)
+
+// These constants keep length of supported headers in bytes.
+//
+// IPv6Len - minimum length of IPv6 header in bytes. It can be higher and it
+// is not determined inside packet. Only default minimum size is used.
+//
+// IPv4MinLen and TCPMinLen are used only in packet generation functions.
+//
+// In parsing we take actual length of TCP header from DataOff field and length of
+// IPv4 take from Ihl field.
+const (
+	EtherLen   = 14
+	IPv4MinLen = 20
+	IPv6Len    = 40
+	TCPMinLen  = 20
+	UDPLen     = 8
+)
+
+// EtherIPv6Len is used in packet parsing only when we sure that
+// the next protocol is TCP or UDP.
+const EtherIPv6Len = EtherLen + IPv6Len
+
 type LogType uint8
 
 const (

--- a/flow/flow.go
+++ b/flow/flow.go
@@ -581,6 +581,11 @@ func SetMerger(InArray ...*Flow) (OUT *Flow) {
 	return OUT
 }
 
+// Returns default MAC address of an Ethernet port.
+func GetPortMACAddress(port uint8) [common.EtherAddrLen]uint8 {
+	return low.GetPortMACAddress(port)
+}
+
 func receive(parameters interface{}, coreId uint8) {
 	srp := parameters.(*receiveParameters)
 	low.Receive(srp.port, srp.queue, srp.out, coreId)

--- a/low/low.go
+++ b/low/low.go
@@ -45,6 +45,17 @@ type Mbuf C.struct_rte_mbuf
 // TODO need to investigate more elegant way to return variables from C part
 var mainMempool *C.struct_rte_mempool
 
+func GetPortMACAddress(port uint8) [common.EtherAddrLen]uint8 {
+	var mac [common.EtherAddrLen]uint8
+	var cmac C.struct_ether_addr
+
+	C.rte_eth_macaddr_get(C.uint8_t(port), &cmac)
+	for i := range mac {
+		mac[i] = uint8(cmac.addr_bytes[i])
+	}
+	return mac
+}
+
 func GetPacketDataStartPointer(mb *Mbuf) uintptr {
 	return uintptr(mb.buf_addr) + uintptr(mb.data_off)
 }

--- a/packet/packet.go
+++ b/packet/packet.go
@@ -43,6 +43,7 @@ package packet
 
 import (
 	"fmt"
+	. "github.com/intel-go/yanff/common"
 	"github.com/intel-go/yanff/low"
 	"unsafe"
 )
@@ -58,46 +59,6 @@ func init() {
 }
 
 // TODO Add function to write user data after headers and set "data" field
-
-// Supported EtherType for L2
-const (
-	IPV4Number = 0x0800
-	IPV6Number = 0x86dd
-)
-
-// Supported L4 types
-const (
-	IPNumber  = 0x04
-	TCPNumber = 0x06
-	UDPNumber = 0x11
-)
-
-// Length of addresses.
-const (
-	EtherAddrLen = 6
-	IPv6AddrLen  = 16
-)
-
-// These constants keep length of supported headers in bytes.
-//
-// IPv6Len - minimum length of IPv6 header in bytes. It can be higher and it
-// is not determined inside packet. Only default minimum size is used.
-//
-// IPv4MinLen and TCPMinLen are used only in packet generation functions.
-//
-// In parsing we take actual length of TCP header from DataOff field and length of
-// IPv4 take from Ihl field.
-const (
-	EtherLen   = 14
-	IPv4MinLen = 20
-	IPv6Len    = 40
-	TCPMinLen  = 20
-	UDPLen     = 8
-)
-
-// EtherIPv6Len is used in packet parsing only when we sure that
-// the next protocol is TCP or UDP.
-const EtherIPv6Len = EtherLen + IPv6Len
 
 // These structures must be consistent with these C duplications
 // L2 header from DPDK: lib/librte_ether/rte_ehter.h

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -164,10 +164,10 @@ func rawL2Parse(rules *rawL2Rules, jp *L2Rules) {
 			jp.eth[i].ID = 0
 			jp.eth[i].IDMask = 0
 		case "ipv4", "Ipv4", "IPv4", "IPV4", "0x0800":
-			jp.eth[i].ID = packet.IPV4Number
+			jp.eth[i].ID = common.IPV4Number
 			jp.eth[i].IDMask = 0xffff
 		case "ipv6", "Ipv6", "IPv6", "IPV6", "0x86dd":
-			jp.eth[i].ID = packet.IPV6Number
+			jp.eth[i].ID = common.IPV6Number
 			jp.eth[i].IDMask = 0xffff
 		default:
 			common.LogError(common.Debug, "Incorrect JSON request: ", jup[i].ID)
@@ -194,10 +194,10 @@ func rawL3Parse(rules *rawL3Rules, jp *L3Rules) {
 			l4temp.ID = 0
 			l4temp.IDMask = 0
 		case "tcp", "TCP", "Tcp", "0x06", "6":
-			l4temp.ID = packet.TCPNumber
+			l4temp.ID = common.TCPNumber
 			l4temp.IDMask = 0xff
 		case "udp", "UDP", "Udp", "0x11", "17":
-			l4temp.ID = packet.UDPNumber
+			l4temp.ID = common.UDPNumber
 			l4temp.IDMask = 0xff
 		default:
 			common.LogError(common.Debug, "Incorrect JSON request: ", jup[i].ID)

--- a/test/performance/ipsec.go
+++ b/test/performance/ipsec.go
@@ -1,6 +1,7 @@
 // Only IPv4, Only tunnel, Only ESP, Only AES-128-CBC
 package main
 
+import "github.com/intel-go/yanff/common"
 import "github.com/intel-go/yanff/flow"
 import "github.com/intel-go/yanff/packet"
 
@@ -58,8 +59,8 @@ const MODE_1230 = 1230
 const espHeadLen = 24
 const authLen = 12
 const espTailLen = authLen + 2
-const etherLen = packet.EtherLen
-const outerIPLen = packet.IPv4MinLen
+const etherLen = common.EtherLen
+const outerIPLen = common.IPv4MinLen
 
 type ESPHeader struct {
 	SPI uint32
@@ -146,7 +147,7 @@ func encapsulationSPI123(currentPacket *packet.Packet, context0 flow.UserContext
 
 	currentESPTail := (*ESPTail)(unsafe.Pointer(currentPacket.Unparsed + uintptr(new_length) - espTailLen))
 	currentESPTail.paddingLen = paddingLength
-	currentESPTail.nextIP = packet.IPNumber
+	currentESPTail.nextIP = common.IPNumber
 
 	// Encryption
 	EncryptionPart := (*[math.MaxInt32]byte)(unsafe.Pointer(currentPacket.Unparsed))[etherLen+outerIPLen+espHeadLen : new_length-authLen]


### PR DESCRIPTION
To do this it is necessary to move constants from packet to common
because they have to be accessible from low. All constants were moved
so that they remain together. This resulted in quite a lot of changes
in packet and some tests.