### PR TITLE
First attempt to clean our packet structure

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -27,9 +27,9 @@ const (
 // Supported L4 types
 const (
 	ICMPNumber = 0x01
-	IPNumber  = 0x04
-	TCPNumber = 0x06
-	UDPNumber = 0x11
+	IPNumber   = 0x04
+	TCPNumber  = 0x06
+	UDPNumber  = 0x11
 )
 
 // These constants keep length of supported headers in bytes.
@@ -49,10 +49,6 @@ const (
 	TCPMinLen  = 20
 	UDPLen     = 8
 )
-
-// EtherIPv6Len is used in packet parsing only when we sure that
-// the next protocol is TCP or UDP.
-const EtherIPv6Len = EtherLen + IPv6Len
 
 type LogType uint8
 

--- a/examples/demo.go
+++ b/examples/demo.go
@@ -16,7 +16,7 @@ var (
 	L3Rules *rules.L3Rules
 	load    uint
 
-	inport  uint
+	inport   uint
 	outport1 uint
 	outport2 uint
 )
@@ -29,7 +29,7 @@ func main() {
 	flag.Parse()
 
 	// Initialize YANFF library at 16 cores by default
-	config := flow.Config {
+	config := flow.Config{
 		CPUCoresNumber: 16,
 	}
 	flow.SystemInit(&config)
@@ -56,7 +56,7 @@ func main() {
 }
 
 func L3Separator(currentPacket *packet.Packet, context flow.UserContext) bool {
-	currentPacket.ParseEtherIPv4()
+	currentPacket.ParseIPv4()
 	localL2Rules := L2Rules
 	localL3Rules := L3Rules
 	return rules.L2_ACL_permit(currentPacket, localL2Rules) &&

--- a/test/performance/latency/latency-part1.go
+++ b/test/performance/latency/latency-part1.go
@@ -162,7 +162,7 @@ func generatePackets(pkt *packet.Packet, context flow.UserContext) {
 		fmt.Println("TEST FAILED")
 		panic("Failed to create new packet")
 	}
-	if packet.InitEmptyEtherIPv4UDPPacket(pkt, uint(payloadSize)) == false {
+	if packet.InitEmptyIPv4UDPPacket(pkt, uint(payloadSize)) == false {
 		fmt.Println("TEST FAILED")
 		panic("Failed to init empty packet")
 	}

--- a/test/performance/perf_light.go
+++ b/test/performance/perf_light.go
@@ -12,10 +12,10 @@ import "flag"
 var (
 	mode uint
 
-	inport1 uint
-	inport2 uint
-	outport1 uint
-	outport2 uint
+	inport1     uint
+	inport2     uint
+	outport1    uint
+	outport2    uint
 	noscheduler bool
 )
 
@@ -29,8 +29,8 @@ func main() {
 	flag.Parse()
 
 	// Initialize YANFF library at 15 cores by default
-	config := flow.Config {
-		CPUCoresNumber: 15,
+	config := flow.Config{
+		CPUCoresNumber:   15,
 		DisableScheduler: noscheduler,
 	}
 	flow.SystemInit(&config)
@@ -62,11 +62,11 @@ func heavyFunc0(currentPacket *packet.Packet, context flow.UserContext) {
 }
 
 func heavyFunc1(currentPacket *packet.Packet, context flow.UserContext) {
-	currentPacket.ParseEtherIPv4()
+	currentPacket.ParseIPv4()
 }
 
 func heavyFunc2(currentPacket *packet.Packet, context flow.UserContext) {
-	currentPacket.ParseEtherIPv4()
+	currentPacket.ParseIPv4()
 	T := (currentPacket.IPv4.DstAddr)
 	currentPacket.IPv4.SrcAddr = 263 + (T)
 }

--- a/test/performance/perf_main.go
+++ b/test/performance/perf_main.go
@@ -57,7 +57,7 @@ func main() {
 }
 
 func heavyFunc(currentPacket *packet.Packet, context flow.UserContext) {
-	currentPacket.ParseEtherIPv4()
+	currentPacket.ParseIPv4()
 	T := currentPacket.IPv4.DstAddr
 	for j := uint32(0); j < uint32(load); j++ {
 		T += j

--- a/test/performance/perf_seq.go
+++ b/test/performance/perf_seq.go
@@ -81,7 +81,7 @@ func main() {
 }
 
 func heavyFunc(currentPacket *packet.Packet, context flow.UserContext) {
-	currentPacket.ParseEtherIPv4()
+	currentPacket.ParseIPv4()
 	T := (currentPacket.IPv4.DstAddr)
 	for j := uint(0); j < load; j++ {
 		T += uint32(j)

--- a/test/stability/test1/part1.go
+++ b/test/stability/test1/part1.go
@@ -93,7 +93,7 @@ func main() {
 }
 
 func generatePacket(emptyPacket *packet.Packet, context flow.UserContext) {
-	if packet.InitEmptyEtherIPv4UDPPacket(emptyPacket, uint(PACKET_SIZE)) == false {
+	if packet.InitEmptyIPv4UDPPacket(emptyPacket, uint(PACKET_SIZE)) == false {
 		fmt.Println("TEST FAILED")
 		panic("Failed to init empty packet")
 	}

--- a/test/stability/test_handle2/test-handle2-part1.go
+++ b/test/stability/test_handle2/test-handle2-part1.go
@@ -130,14 +130,14 @@ func generatePacketGroup1(pkt *packet.Packet, context flow.UserContext) {
 	if pkt == nil {
 		panic("Failed to create new packet")
 	}
-	if packet.InitEmptyEtherIPv4UDPPacket(pkt, PAYLOAD_SIZE) == false {
+	if packet.InitEmptyIPv4UDPPacket(pkt, PAYLOAD_SIZE) == false {
 		panic("Failed to init empty packet")
 	}
 	pkt.UDP.DstPort = packet.SwapBytesUint16(DSTPORT_1)
 
 	// Extract headers of packet
-	headerSize := uintptr(pkt.Data) - pkt.Unparsed
-	hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Unparsed))[0:headerSize]
+	headerSize := uintptr(pkt.Data) - pkt.Start()
+	hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Start()))[0:headerSize]
 	ptr := (*PacketData)(pkt.Data)
 	ptr.HdrsMD5 = md5.Sum(hdrs)
 
@@ -153,14 +153,14 @@ func generatePacketGroup2(pkt *packet.Packet, context flow.UserContext) {
 	if pkt == nil {
 		panic("Failed to create new packet")
 	}
-	if packet.InitEmptyEtherIPv4UDPPacket(pkt, PAYLOAD_SIZE) == false {
+	if packet.InitEmptyIPv4UDPPacket(pkt, PAYLOAD_SIZE) == false {
 		panic("Failed to init empty packet")
 	}
 	pkt.UDP.DstPort = packet.SwapBytesUint16(DSTPORT_2)
 
 	// Extract headers of packet
-	headerSize := uintptr(pkt.Data) - pkt.Unparsed
-	hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Unparsed))[0:headerSize]
+	headerSize := uintptr(pkt.Data) - pkt.Start()
+	hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Start()))[0:headerSize]
 	ptr := (*PacketData)(pkt.Data)
 	ptr.HdrsMD5 = md5.Sum(hdrs)
 
@@ -176,14 +176,14 @@ func generatePacketGroup3(pkt *packet.Packet, context flow.UserContext) {
 	if pkt == nil {
 		panic("Failed to create new packet")
 	}
-	if packet.InitEmptyEtherIPv4UDPPacket(pkt, PAYLOAD_SIZE) == false {
+	if packet.InitEmptyIPv4UDPPacket(pkt, PAYLOAD_SIZE) == false {
 		panic("Failed to init empty packet")
 	}
 	pkt.UDP.DstPort = packet.SwapBytesUint16(DSTPORT_3)
 
 	// Extract headers of packet
-	headerSize := uintptr(pkt.Data) - pkt.Unparsed
-	hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Unparsed))[0:headerSize]
+	headerSize := uintptr(pkt.Data) - pkt.Start()
+	hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Start()))[0:headerSize]
 	ptr := (*PacketData)(pkt.Data)
 	ptr.HdrsMD5 = md5.Sum(hdrs)
 
@@ -204,8 +204,8 @@ func checkInputFlow(pkt *packet.Packet, context flow.UserContext) {
 		ptr := (*PacketData)(pkt.Data)
 
 		// Recompute hash to check how many packets are valid
-		headerSize := uintptr(pkt.Data) - pkt.Unparsed
-		hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Unparsed))[0:headerSize]
+		headerSize := uintptr(pkt.Data) - pkt.Start()
+		hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Start()))[0:headerSize]
 		hash := md5.Sum(hdrs)
 
 		if hash != ptr.HdrsMD5 {

--- a/test/stability/test_handle2/test-handle2-part2.go
+++ b/test/stability/test_handle2/test-handle2-part2.go
@@ -15,7 +15,7 @@ var (
 	L3Rules *rules.L3Rules
 
 	outport uint
-	inport uint
+	inport  uint
 )
 
 // Main function for constructing packet processing graph.
@@ -25,7 +25,7 @@ func main() {
 	flag.Parse()
 
 	// Init YANFF system at 16 available cores.
-	config := flow.Config {
+	config := flow.Config{
 		CPUCoresNumber: 16,
 	}
 	flow.SystemInit(&config)
@@ -47,6 +47,6 @@ func main() {
 }
 
 func L3Handler(pkt *packet.Packet, context flow.UserContext) bool {
-	pkt.ParseEtherIPv4UDP()
+	pkt.ParseIPv4UDP()
 	return rules.L3_ACL_permit(pkt, L3Rules)
 }

--- a/test/stability/test_merge/test-merge-part1.go
+++ b/test/stability/test_merge/test-merge-part1.go
@@ -130,14 +130,14 @@ func generatePacketGroup1(pkt *packet.Packet, context flow.UserContext) {
 	if pkt == nil {
 		panic("Failed to create new packet")
 	}
-	if packet.InitEmptyEtherIPv4UDPPacket(pkt, PAYLOAD_SIZE) == false {
+	if packet.InitEmptyIPv4UDPPacket(pkt, PAYLOAD_SIZE) == false {
 		panic("Failed to init empty packet")
 	}
 	pkt.IPv4.SrcAddr = IPV4ADDR_1
 
 	// Extract headers of packet
-	headerSize := uintptr(pkt.Data) - pkt.Unparsed
-	hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Unparsed))[0:headerSize]
+	headerSize := uintptr(pkt.Data) - pkt.Start()
+	hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Start()))[0:headerSize]
 	ptr := (*PacketData)(pkt.Data)
 	ptr.HdrsMD5 = md5.Sum(hdrs)
 
@@ -148,14 +148,14 @@ func generatePacketGroup2(pkt *packet.Packet, context flow.UserContext) {
 	if pkt == nil {
 		panic("Failed to create new packet")
 	}
-	if packet.InitEmptyEtherIPv4UDPPacket(pkt, PAYLOAD_SIZE) == false {
+	if packet.InitEmptyIPv4UDPPacket(pkt, PAYLOAD_SIZE) == false {
 		panic("Failed to init empty packet")
 	}
 	pkt.IPv4.SrcAddr = IPV4ADDR_2
 
 	// Extract headers of packet
-	headerSize := uintptr(pkt.Data) - pkt.Unparsed
-	hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Unparsed))[0:headerSize]
+	headerSize := uintptr(pkt.Data) - pkt.Start()
+	hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Start()))[0:headerSize]
 	ptr := (*PacketData)(pkt.Data)
 	ptr.HdrsMD5 = md5.Sum(hdrs)
 
@@ -175,8 +175,8 @@ func checkPackets(pkt *packet.Packet, context flow.UserContext) {
 		ptr := (*PacketData)(pkt.Data)
 
 		// Recompute hash to check how many packets are valid
-		headerSize := uintptr(pkt.Data) - pkt.Unparsed
-		hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Unparsed))[0:headerSize]
+		headerSize := uintptr(pkt.Data) - pkt.Start()
+		hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Start()))[0:headerSize]
 		hash := md5.Sum(hdrs)
 
 		if hash != ptr.HdrsMD5 {

--- a/test/stability/test_partition/test-partition-part1.go
+++ b/test/stability/test_partition/test-partition-part1.go
@@ -129,13 +129,13 @@ func generatePacket(pkt *packet.Packet, context flow.UserContext) {
 	if pkt == nil {
 		panic("Failed to create new packet")
 	}
-	if packet.InitEmptyEtherIPv4UDPPacket(pkt, PAYLOAD_SIZE) == false {
+	if packet.InitEmptyIPv4UDPPacket(pkt, PAYLOAD_SIZE) == false {
 		panic("Failed to init empty packet")
 	}
 
 	// Extract headers of packet
-	headerSize := uintptr(pkt.Data) - pkt.Unparsed
-	hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Unparsed))[0:headerSize]
+	headerSize := uintptr(pkt.Data) - pkt.Start()
+	hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Start()))[0:headerSize]
 	ptr := (*PacketData)(pkt.Data)
 	ptr.HdrsMD5 = md5.Sum(hdrs)
 
@@ -154,8 +154,8 @@ func checkInputFlow1(pkt *packet.Packet, context flow.UserContext) {
 		ptr := (*PacketData)(pkt.Data)
 
 		// Recompute hash to check how many packets are valid
-		headerSize := uintptr(pkt.Data) - pkt.Unparsed
-		hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Unparsed))[0:headerSize]
+		headerSize := uintptr(pkt.Data) - pkt.Start()
+		hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Start()))[0:headerSize]
 		hash := md5.Sum(hdrs)
 
 		if hash != ptr.HdrsMD5 {
@@ -183,8 +183,8 @@ func checkInputFlow2(pkt *packet.Packet, context flow.UserContext) {
 		ptr := (*PacketData)(pkt.Data)
 
 		// Recompute hash to check how many packets are valid
-		headerSize := uintptr(pkt.Data) - pkt.Unparsed
-		hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Unparsed))[0:headerSize]
+		headerSize := uintptr(pkt.Data) - pkt.Start()
+		hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Start()))[0:headerSize]
 		hash := md5.Sum(hdrs)
 
 		if hash != ptr.HdrsMD5 {

--- a/test/stability/test_separate/test-separate-part1.go
+++ b/test/stability/test_separate/test-separate-part1.go
@@ -143,7 +143,7 @@ func generatePacket(pkt *packet.Packet, context flow.UserContext) {
 	}
 	atomic.AddUint64(&count, 1)
 
-	if packet.InitEmptyEtherIPv4UDPPacket(pkt, PAYLOAD_SIZE) == false {
+	if packet.InitEmptyIPv4UDPPacket(pkt, PAYLOAD_SIZE) == false {
 		panic("Failed to init empty packet")
 	}
 
@@ -155,8 +155,8 @@ func generatePacket(pkt *packet.Packet, context flow.UserContext) {
 	} else {
 		pkt.UDP.DstPort = packet.SwapBytesUint16(DSTPORT_3)
 	}
-	headerSize := uintptr(pkt.Data) - pkt.Unparsed
-	hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Unparsed))[0:headerSize]
+	headerSize := uintptr(pkt.Data) - pkt.Start()
+	hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Start()))[0:headerSize]
 	ptr := (*PacketData)(pkt.Data)
 	ptr.HdrsMD5 = md5.Sum(hdrs)
 }
@@ -173,8 +173,8 @@ func checkInputFlow1(pkt *packet.Packet, context flow.UserContext) {
 		ptr := (*PacketData)(pkt.Data)
 
 		// Recompute hash to check how many packets are valid
-		headerSize := uintptr(pkt.Data) - pkt.Unparsed
-		hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Unparsed))[0:headerSize]
+		headerSize := uintptr(pkt.Data) - pkt.Start()
+		hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Start()))[0:headerSize]
 		hash := md5.Sum(hdrs)
 
 		if hash != ptr.HdrsMD5 {
@@ -201,8 +201,8 @@ func checkInputFlow2(pkt *packet.Packet, context flow.UserContext) {
 		ptr := (*PacketData)(pkt.Data)
 
 		// Recompute hash to check how many packets are valid
-		headerSize := uintptr(pkt.Data) - pkt.Unparsed
-		hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Unparsed))[0:headerSize]
+		headerSize := uintptr(pkt.Data) - pkt.Start()
+		hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Start()))[0:headerSize]
 		hash := md5.Sum(hdrs)
 
 		if hash != ptr.HdrsMD5 {

--- a/test/stability/test_separate/test-separate-part2.go
+++ b/test/stability/test_separate/test-separate-part2.go
@@ -14,7 +14,7 @@ import (
 var (
 	L3Rules *rules.L3Rules
 
-	inport  uint
+	inport   uint
 	outport1 uint
 	outport2 uint
 )
@@ -27,7 +27,7 @@ func main() {
 	flag.Parse()
 
 	// Init YANFF system at 16 available cores.
-	config := flow.Config {
+	config := flow.Config{
 		CPUCoresNumber: 16,
 	}
 	flow.SystemInit(&config)
@@ -51,6 +51,6 @@ func main() {
 }
 
 func L3Separator(pkt *packet.Packet, context flow.UserContext) bool {
-	pkt.ParseEtherIPv4UDP()
+	pkt.ParseIPv4UDP()
 	return rules.L3_ACL_permit(pkt, L3Rules)
 }

--- a/test/stability/test_split/test-split-part1.go
+++ b/test/stability/test_split/test-split-part1.go
@@ -153,7 +153,7 @@ func generatePacket(pkt *packet.Packet, context flow.UserContext) {
 	}
 	atomic.AddUint64(&count, 1)
 
-	if packet.InitEmptyEtherIPv4UDPPacket(pkt, PAYLOAD_SIZE) == false {
+	if packet.InitEmptyIPv4UDPPacket(pkt, PAYLOAD_SIZE) == false {
 		panic("Failed to init empty packet")
 	}
 
@@ -166,8 +166,8 @@ func generatePacket(pkt *packet.Packet, context flow.UserContext) {
 	}
 
 	// Extract headers of packet
-	headerSize := uintptr(pkt.Data) - pkt.Unparsed
-	hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Unparsed))[0:headerSize]
+	headerSize := uintptr(pkt.Data) - pkt.Start()
+	hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Start()))[0:headerSize]
 	ptr := (*PacketData)(pkt.Data)
 	ptr.HdrsMD5 = md5.Sum(hdrs)
 }
@@ -184,8 +184,8 @@ func checkInputFlow1(pkt *packet.Packet, context flow.UserContext) {
 		ptr := (*PacketData)(pkt.Data)
 
 		// Recompute hash to check how many packets are valid
-		headerSize := uintptr(pkt.Data) - pkt.Unparsed
-		hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Unparsed))[0:headerSize]
+		headerSize := uintptr(pkt.Data) - pkt.Start()
+		hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Start()))[0:headerSize]
 		hash := md5.Sum(hdrs)
 
 		if hash != ptr.HdrsMD5 {
@@ -214,8 +214,8 @@ func checkInputFlow2(pkt *packet.Packet, context flow.UserContext) {
 		ptr := (*PacketData)(pkt.Data)
 
 		// Recompute hash to check how many packets are valid
-		headerSize := uintptr(pkt.Data) - pkt.Unparsed
-		hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Unparsed))[0:headerSize]
+		headerSize := uintptr(pkt.Data) - pkt.Start()
+		hdrs := (*[1000]byte)(unsafe.Pointer(pkt.Start()))[0:headerSize]
 		hash := md5.Sum(hdrs)
 
 		if hash != ptr.HdrsMD5 {

--- a/test/stash/create_packet_example.go
+++ b/test/stash/create_packet_example.go
@@ -16,7 +16,7 @@ var buffer []byte
 
 func main() {
 	// By default this example generates 128-byte empty packets with
-	// InitEmptyEtherIPv4TCPPacket() and set Ethernet destination address.
+	// InitEmptyIPv4TCPPacket() and set Ethernet destination address.
 	// If flag enabled, generates packets with PacketFromByte() from raw buffer.
 	enablePacketFromByte := flag.Bool("pfb", false, "enables generating packets with PacketFromByte() from raw buffer. Otherwise, by default empty 128-byte packets are generated")
 	flag.Parse()
@@ -41,7 +41,7 @@ func main() {
 
 func generatePacket(pkt *packet.Packet, context flow.UserContext) {
 	// Total packet size will be 14+20+20+70+4(crc)=128 bytes
-	if packet.InitEmptyEtherPacket(pkt, 70) == true {
+	if packet.InitEmptyPacket(pkt, 70) == true {
 		pkt.Ether.DAddr = [6]uint8{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}
 	}
 }

--- a/test/stash/send_fixed_number.go
+++ b/test/stash/send_fixed_number.go
@@ -50,7 +50,7 @@ func main() {
 
 func generatePacket(pkt *packet.Packet, context flow.UserContext) {
 	sent := atomic.LoadInt64(&count)
-	if packet.InitEmptyEtherIPv4TCPPacket(pkt, payload_size) == false {
+	if packet.InitEmptyIPv4TCPPacket(pkt, payload_size) == false {
 		panic("Failed to init empty packet")
 	}
 	pkt.Ether.DAddr = [6]uint8{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}


### PR DESCRIPTION
As we handle only ethernet packets -> merge Unparsed and Ether fields of packet
It means:
1) packet structure is now inside one cache-line
2) ether field is parsed by default like "start of packet"
In API:
1) removed all ParseEther* functions -> parse ether by default
2) removed ParseL2 function -> parse ether by default
3) rename all InitEmptyEther* functions to InitEmpty*
4) removing of public Unparsed field. Users should use "packet.Start()"
function for pointer to first packet byte instead of Unparsed field
Really packet.Start function returns casted packet.Ether field and is inlined
5) ParseL3 returns length of L3 protocol
6) ParseL4 returns length of L3 + L4 protocol