### PR TITLE
Added ip reassembly functionality

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -1171,6 +1171,8 @@ func read(parameters interface{}, coreID uint8) {
 			}
 			tempPacket.ReadPcapOnePacket(f)
 		}
+		// TODO we need packet reassembly here. However we don't
+		// use mbuf packet_type here, so it is impossible.
 		safeEnqueue(OUT, buf, 1)
 	}
 }


### PR DESCRIPTION
Functionality is added as part of receive function in C part
Under ifdef which is false by default
Added some TODOs for full implementation
Now it is impossible to use reassembly output in current packet structure:
commit for dealing with mbuf chaining will follow this one

Performance of framework with switched off reassembly didn't change.