### PR TITLE
Added basic support of chained mbufs = scattered packets

### DIFF
--- a/low/low.go
+++ b/low/low.go
@@ -540,7 +540,12 @@ func GetRawPacketBytesMbuf(mb *Mbuf) []byte {
 	return (*[1 << 30]byte)(unsafe.Pointer(dataPtr))[:dataLen]
 }
 
-// GetDataLenMbuf returns amount of data in a given Mbuf.
+// GetPktLenMbuf returns amount of data in a given chain of Mbufs - whole packet
+func GetPktLenMbuf(mb *Mbuf) uint {
+	return uint(mb.pkt_len)
+}
+
+// GetDataLenMbuf returns amount of data in a given Mbuf - one segment if scattered
 func GetDataLenMbuf(mb *Mbuf) uint {
 	return uint(mb.data_len)
 }


### PR DESCRIPTION
For now only Next pointer in packet structure is added.
This allows to have basic access to all packet segments.
Other facilities like copying to one slice or Reader implementation
will come later.

GetPacketLen - now returns length of whole packet
GetPacketSegmentLen - new function, return length of current segment

Encapsulate/Decapsulate functions aren't supported with scattered packets now.

---

This functionality isn't supported by tests - should be added later. Performance wasn't tested, however I suppose that one additional field inside packet structure in the same cache line won't influence overall performance. More commits will be added later.