### PR TITLE
Added filling Proto field for IP6 protocol

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -26,10 +26,11 @@ const (
 
 // Supported L4 types
 const (
-	ICMPNumber = 0x01
-	IPNumber   = 0x04
-	TCPNumber  = 0x06
-	UDPNumber  = 0x11
+	ICMPNumber       = 0x01
+	IPNumber         = 0x04
+	TCPNumber        = 0x06
+	UDPNumber        = 0x11
+	IPv6NoNextHeader = 0x3B
 )
 
 // Supported ICMP Types

--- a/packet/packet.go
+++ b/packet/packet.go
@@ -43,9 +43,10 @@ package packet
 
 import (
 	"fmt"
+	"unsafe"
+
 	. "github.com/intel-go/yanff/common"
 	"github.com/intel-go/yanff/low"
-	"unsafe"
 )
 
 var mbufStructSize uintptr
@@ -440,6 +441,8 @@ func InitEmptyIPv6Packet(packet *Packet, plSize uint) bool {
 	packet.ParseL3()
 	packet.GetIPv6().PayloadLen = SwapBytesUint16(uint16(plSize))
 	packet.GetIPv6().VtcFlow = SwapBytesUint32(0x60 << 24) // IP version
+	packet.GetIPv6().Proto = IPv6NoNextHeader
+
 	return true
 }
 


### PR DESCRIPTION
to init ipv6 header with data proto field should be set to "No Next
Header" it is 0x3B value. It was 0 which means "Hop-By-Hop Options Extension Header"  which must be supplied with some options, but I suppose if user calls InitEmptyIPv6Packet