### PR TITLE
examples: fix issues pointed by "go lint"

### DIFF
--- a/examples/Firewall.go
+++ b/examples/Firewall.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"flag"
+
 	"github.com/intel-go/yanff/flow"
 	"github.com/intel-go/yanff/packet"
 	"github.com/intel-go/yanff/rules"

--- a/examples/clonable_pcap_dumper.go
+++ b/examples/clonable_pcap_dumper.go
@@ -7,9 +7,10 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
+
 	"github.com/intel-go/yanff/flow"
 	"github.com/intel-go/yanff/packet"
-	"os"
 )
 
 var (
@@ -53,7 +54,7 @@ func (pd pcapdumperParameters) Copy() interface{} {
 		fmt.Println("Cannot create file: ", err)
 		os.Exit(0)
 	}
-	cloneNumber += 1
+	cloneNumber++
 	packet.WritePcapGlobalHdr(f)
 	pdp := pcapdumperParameters{f: f}
 	return pdp

--- a/examples/demo.go
+++ b/examples/demo.go
@@ -4,12 +4,14 @@
 
 package main
 
-import "github.com/intel-go/yanff/flow"
-import "github.com/intel-go/yanff/packet"
-import "github.com/intel-go/yanff/rules"
+import (
+	"flag"
+	"time"
 
-import "flag"
-import "time"
+	"github.com/intel-go/yanff/flow"
+	"github.com/intel-go/yanff/packet"
+	"github.com/intel-go/yanff/rules"
+)
 
 var (
 	l2Rules *rules.L2Rules
@@ -68,7 +70,7 @@ func heavyFunc(currentPacket *packet.Packet, context flow.UserContext) {
 }
 
 func updateSeparateRules() {
-	for true {
+	for {
 		time.Sleep(time.Second * 5)
 		l2Rules = rules.GetL2RulesFromJSON("demoL2_ACL.json")
 		l3Rules = rules.GetL3RulesFromJSON("demoL3_ACL.json")

--- a/examples/dump.go
+++ b/examples/dump.go
@@ -7,6 +7,7 @@ package main
 import (
 	"flag"
 	"fmt"
+
 	"github.com/intel-go/yanff/flow"
 	"github.com/intel-go/yanff/packet"
 )

--- a/examples/tutorial/common.go
+++ b/examples/tutorial/common.go
@@ -3,12 +3,13 @@ package main
 import (
 	"encoding/json"
 	"flag"
-	"github.com/intel-go/yanff/common"
-	"github.com/intel-go/yanff/flow"
-	"github.com/intel-go/yanff/packet"
 	"log"
 	"net"
 	"os"
+
+	"github.com/intel-go/yanff/common"
+	"github.com/intel-go/yanff/flow"
+	"github.com/intel-go/yanff/packet"
 )
 
 var config map[string][]string
@@ -16,7 +17,7 @@ var dstMac0 [common.EtherAddrLen]uint8
 var srcMac0 [common.EtherAddrLen]uint8
 var dstMac1 [common.EtherAddrLen]uint8
 var srcMac1 [common.EtherAddrLen]uint8
-var modifyPacket []interface{} = []interface{}{modifyPacket0, modifyPacket1}
+var modifyPacket = []interface{}{modifyPacket0, modifyPacket1}
 
 // readConfig function reads and parses config file
 func readConfig(fileName string) error {

--- a/examples/tutorial/genscripts.go
+++ b/examples/tutorial/genscripts.go
@@ -79,7 +79,7 @@ stop 1
 `
 )
 
-var workaroundTargets map[string]struct{} = map[string]struct{}{
+var workaroundTargets = map[string]struct{}{
 	"dbdw14": {},
 	"dbdw15": {},
 	"dbdw16": {},

--- a/examples/tutorial/step10.go
+++ b/examples/tutorial/step10.go
@@ -1,13 +1,16 @@
 package main
 
-import "time"
-import "github.com/intel-go/yanff/common"
-import "github.com/intel-go/yanff/flow"
-import "github.com/intel-go/yanff/packet"
-import "github.com/intel-go/yanff/rules"
+import (
+	"time"
+
+	"github.com/intel-go/yanff/common"
+	"github.com/intel-go/yanff/flow"
+	"github.com/intel-go/yanff/packet"
+	"github.com/intel-go/yanff/rules"
+)
 
 var (
-	L3Rules *rules.L3Rules
+	l3Rules *rules.L3Rules
 )
 
 const flowN = 3
@@ -16,7 +19,7 @@ func main() {
 	config := flow.Config{}
 	flow.SystemInit(&config)
 	initCommonState()
-	L3Rules = rules.GetL3RulesFromORIG("rules2.conf")
+	l3Rules = rules.GetL3RulesFromORIG("rules2.conf")
 	go updateSeparateRules()
 	firstFlow := flow.SetReceiver(0)
 	outputFlows := flow.SetSplitter(firstFlow, mySplitter, flowN, nil)
@@ -30,7 +33,7 @@ func main() {
 }
 
 func mySplitter(cur *packet.Packet, ctx flow.UserContext) uint {
-	localL3Rules := L3Rules
+	localL3Rules := l3Rules
 	return rules.L3ACLPort(cur, localL3Rules)
 }
 
@@ -47,8 +50,8 @@ func myHandler(curV []*packet.Packet, num uint, ctx flow.UserContext) {
 }
 
 func updateSeparateRules() {
-	for true {
+	for {
 		time.Sleep(time.Second * 5)
-		L3Rules = rules.GetL3RulesFromORIG("rules2.conf")
+		l3Rules = rules.GetL3RulesFromORIG("rules2.conf")
 	}
 }

--- a/examples/tutorial/step11.go
+++ b/examples/tutorial/step11.go
@@ -1,13 +1,16 @@
 package main
 
-import "time"
-import "github.com/intel-go/yanff/common"
-import "github.com/intel-go/yanff/flow"
-import "github.com/intel-go/yanff/packet"
-import "github.com/intel-go/yanff/rules"
+import (
+	"time"
+
+	"github.com/intel-go/yanff/common"
+	"github.com/intel-go/yanff/flow"
+	"github.com/intel-go/yanff/packet"
+	"github.com/intel-go/yanff/rules"
+)
 
 var (
-	L3Rules *rules.L3Rules
+	l3Rules *rules.L3Rules
 )
 
 const flowN = 3
@@ -16,7 +19,7 @@ func main() {
 	config := flow.Config{}
 	flow.SystemInit(&config)
 	initCommonState()
-	L3Rules = rules.GetL3RulesFromORIG("rules2.conf")
+	l3Rules = rules.GetL3RulesFromORIG("rules2.conf")
 	go updateSeparateRules()
 	firstFlow := flow.SetReceiver(0)
 	outputFlows := flow.SetSplitter(firstFlow, mySplitter, flowN, nil)
@@ -30,7 +33,7 @@ func main() {
 }
 
 func mySplitter(cur *packet.Packet, ctx flow.UserContext) uint {
-	localL3Rules := L3Rules
+	localL3Rules := l3Rules
 	return rules.L3ACLPort(cur, localL3Rules)
 }
 
@@ -54,8 +57,8 @@ func heavyCode() {
 }
 
 func updateSeparateRules() {
-	for true {
+	for {
 		time.Sleep(time.Second * 5)
-		L3Rules = rules.GetL3RulesFromORIG("rules2.conf")
+		l3Rules = rules.GetL3RulesFromORIG("rules2.conf")
 	}
 }

--- a/examples/tutorial/step4.go
+++ b/examples/tutorial/step4.go
@@ -1,7 +1,9 @@
 package main
 
-import "github.com/intel-go/yanff/flow"
-import "github.com/intel-go/yanff/packet"
+import (
+	"github.com/intel-go/yanff/flow"
+	"github.com/intel-go/yanff/packet"
+)
 
 func main() {
 	config := flow.Config{}
@@ -23,7 +25,6 @@ func mySeparator(cur *packet.Packet, ctx flow.UserContext) bool {
 	cur.ParseL3()
 	if cur.GetIPv4() != nil && cur.GetTCPForIPv4() != nil && packet.SwapBytesUint16(cur.GetTCPForIPv4().DstPort) == 53 {
 		return false
-	} else {
-		return true
 	}
+	return true
 }

--- a/examples/tutorial/step5.go
+++ b/examples/tutorial/step5.go
@@ -1,18 +1,20 @@
 package main
 
-import "github.com/intel-go/yanff/flow"
-import "github.com/intel-go/yanff/packet"
-import "github.com/intel-go/yanff/rules"
+import (
+	"github.com/intel-go/yanff/flow"
+	"github.com/intel-go/yanff/packet"
+	"github.com/intel-go/yanff/rules"
+)
 
 var (
-	L3Rules *rules.L3Rules
+	l3Rules *rules.L3Rules
 )
 
 func main() {
 	config := flow.Config{}
 	flow.SystemInit(&config)
 	initCommonState()
-	L3Rules = rules.GetL3RulesFromORIG("rules1.conf")
+	l3Rules = rules.GetL3RulesFromORIG("rules1.conf")
 	firstFlow := flow.SetReceiver(0)
 	secondFlow := flow.SetSeparator(firstFlow, mySeparator, nil)
 	flow.SetHandler(firstFlow, modifyPacket[0], nil)
@@ -23,5 +25,5 @@ func main() {
 }
 
 func mySeparator(cur *packet.Packet, ctx flow.UserContext) bool {
-	return rules.L3ACLPermit(cur, L3Rules)
+	return rules.L3ACLPermit(cur, l3Rules)
 }

--- a/examples/tutorial/step6.go
+++ b/examples/tutorial/step6.go
@@ -1,18 +1,20 @@
 package main
 
-import "github.com/intel-go/yanff/flow"
-import "github.com/intel-go/yanff/packet"
-import "github.com/intel-go/yanff/rules"
+import (
+	"github.com/intel-go/yanff/flow"
+	"github.com/intel-go/yanff/packet"
+	"github.com/intel-go/yanff/rules"
+)
 
 var (
-	L3Rules *rules.L3Rules
+	l3Rules *rules.L3Rules
 )
 
 func main() {
 	config := flow.Config{}
 	flow.SystemInit(&config)
 	initCommonState()
-	L3Rules = rules.GetL3RulesFromORIG("rules1.conf")
+	l3Rules = rules.GetL3RulesFromORIG("rules1.conf")
 	firstFlow := flow.SetReceiver(0)
 	secondFlow := flow.SetSeparator(firstFlow, mySeparator, nil)
 	flow.SetHandler(firstFlow, modifyPacket[0], nil)
@@ -22,5 +24,5 @@ func main() {
 }
 
 func mySeparator(cur *packet.Packet, ctx flow.UserContext) bool {
-	return rules.L3ACLPermit(cur, L3Rules)
+	return rules.L3ACLPermit(cur, l3Rules)
 }

--- a/examples/tutorial/step7.go
+++ b/examples/tutorial/step7.go
@@ -1,19 +1,22 @@
 package main
 
-import "time"
-import "github.com/intel-go/yanff/flow"
-import "github.com/intel-go/yanff/packet"
-import "github.com/intel-go/yanff/rules"
+import (
+	"time"
+
+	"github.com/intel-go/yanff/flow"
+	"github.com/intel-go/yanff/packet"
+	"github.com/intel-go/yanff/rules"
+)
 
 var (
-	L3Rules *rules.L3Rules
+	l3Rules *rules.L3Rules
 )
 
 func main() {
 	config := flow.Config{}
 	flow.SystemInit(&config)
 	initCommonState()
-	L3Rules = rules.GetL3RulesFromORIG("rules1.conf")
+	l3Rules = rules.GetL3RulesFromORIG("rules1.conf")
 	go updateSeparateRules()
 	firstFlow := flow.SetReceiver(0)
 	secondFlow := flow.SetSeparator(firstFlow, mySeparator, nil)
@@ -25,13 +28,13 @@ func main() {
 }
 
 func mySeparator(cur *packet.Packet, ctx flow.UserContext) bool {
-	localL3Rules := L3Rules
+	localL3Rules := l3Rules
 	return rules.L3ACLPermit(cur, localL3Rules)
 }
 
 func updateSeparateRules() {
-	for true {
+	for {
 		time.Sleep(time.Second * 5)
-		L3Rules = rules.GetL3RulesFromORIG("rules1.conf")
+		l3Rules = rules.GetL3RulesFromORIG("rules1.conf")
 	}
 }

--- a/examples/tutorial/step8.go
+++ b/examples/tutorial/step8.go
@@ -1,12 +1,15 @@
 package main
 
-import "time"
-import "github.com/intel-go/yanff/flow"
-import "github.com/intel-go/yanff/packet"
-import "github.com/intel-go/yanff/rules"
+import (
+	"time"
+
+	"github.com/intel-go/yanff/flow"
+	"github.com/intel-go/yanff/packet"
+	"github.com/intel-go/yanff/rules"
+)
 
 var (
-	L3Rules *rules.L3Rules
+	l3Rules *rules.L3Rules
 )
 
 const flowN = 3
@@ -15,7 +18,7 @@ func main() {
 	config := flow.Config{}
 	flow.SystemInit(&config)
 	initCommonState()
-	L3Rules = rules.GetL3RulesFromORIG("rules2.conf")
+	l3Rules = rules.GetL3RulesFromORIG("rules2.conf")
 	go updateSeparateRules()
 	firstFlow := flow.SetReceiver(0)
 	outputFlows := flow.SetSplitter(firstFlow, mySplitter, flowN, nil)
@@ -28,13 +31,13 @@ func main() {
 }
 
 func mySplitter(cur *packet.Packet, ctx flow.UserContext) uint {
-	localL3Rules := L3Rules
+	localL3Rules := l3Rules
 	return rules.L3ACLPort(cur, localL3Rules)
 }
 
 func updateSeparateRules() {
-	for true {
+	for {
 		time.Sleep(time.Second * 5)
-		L3Rules = rules.GetL3RulesFromORIG("rules2.conf")
+		l3Rules = rules.GetL3RulesFromORIG("rules2.conf")
 	}
 }

--- a/examples/tutorial/step9.go
+++ b/examples/tutorial/step9.go
@@ -1,13 +1,16 @@
 package main
 
-import "time"
-import "github.com/intel-go/yanff/common"
-import "github.com/intel-go/yanff/flow"
-import "github.com/intel-go/yanff/packet"
-import "github.com/intel-go/yanff/rules"
+import (
+	"time"
+
+	"github.com/intel-go/yanff/common"
+	"github.com/intel-go/yanff/flow"
+	"github.com/intel-go/yanff/packet"
+	"github.com/intel-go/yanff/rules"
+)
 
 var (
-	L3Rules *rules.L3Rules
+	l3Rules *rules.L3Rules
 )
 
 const flowN = 3
@@ -16,7 +19,7 @@ func main() {
 	config := flow.Config{}
 	flow.SystemInit(&config)
 	initCommonState()
-	L3Rules = rules.GetL3RulesFromORIG("rules2.conf")
+	l3Rules = rules.GetL3RulesFromORIG("rules2.conf")
 	go updateSeparateRules()
 	firstFlow := flow.SetReceiver(0)
 	outputFlows := flow.SetSplitter(firstFlow, mySplitter, flowN, nil)
@@ -30,7 +33,7 @@ func main() {
 }
 
 func mySplitter(cur *packet.Packet, ctx flow.UserContext) uint {
-	localL3Rules := L3Rules
+	localL3Rules := l3Rules
 	return rules.L3ACLPort(cur, localL3Rules)
 }
 
@@ -44,8 +47,8 @@ func myHandler(cur *packet.Packet, ctx flow.UserContext) {
 }
 
 func updateSeparateRules() {
-	for true {
+	for {
 		time.Sleep(time.Second * 5)
-		L3Rules = rules.GetL3RulesFromORIG("rules2.conf")
+		l3Rules = rules.GetL3RulesFromORIG("rules2.conf")
 	}
 }


### PR DESCRIPTION
Changes:
**1** - group imports into single `import (...)` clause
**2** - stdlib imports go first, then empty line, then other packages
**3** - `for true {}` should be written as `for {}`
**4** - made L3Rules global unexported (go lint)
**5** - `cloneNumber += 1` replaced with `cloneNumber++` (go lint)
**6** - omit type for `var` that is inferred from RHS (go lint)

**(1)** and **(3)** should be performed by `gofmt -s` (simplify code), but they are not, yet.
`goimports` is also sometimes refuses to re-arrange imports in a proper way, until you manually swap some lines.
The last 3 types of changes are caught by `go lint`.

**Note:** I have not looked into `examples/nat`, because of reasons.