### PR TITLE
Update README to require Go 1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ $GOPATH/src/github.com/intel-go/yanff/test/dpdk/dpdk-17.08/x86_64-native-linuxap
 
 ### Go
 
-Use Go version 1.8 or higher. To check the version of Go, do:
+Use Go version 1.9 or higher. To check the version of Go, do:
 
         go version
         


### PR DESCRIPTION
docs: Update README to require Go 1.9

In this project, `examples/nat/translation.go` uses sync.Map which has
been introduced on Go 1.9 - https://golang.org/doc/go1.9#sync-map. Due
to this, building fails with Go 1.8 env. This patch updates README to
require Go 1.9.

Signed-off-by: Kenjiro Nakayama <nakayamakenjiro@gmail.com>