### PR TITLE
Encapsulate all translation data into one port-pair structure

### DIFF
--- a/examples/nat/cksum.go
+++ b/examples/nat/cksum.go
@@ -10,12 +10,13 @@ import (
 	"unsafe"
 )
 
-func setIPv4UDPChecksum(l3 *packet.IPv4Hdr, l4 *packet.UDPHdr,
+func setIPv4UDPChecksum(pkt *packet.Packet, l3 *packet.IPv4Hdr, l4 *packet.UDPHdr,
 	CalculateChecksum, HWTXChecksum bool) {
 	if CalculateChecksum {
 		if HWTXChecksum {
 			l3.HdrChecksum = 0
 			l4.DgramCksum = packet.SwapBytesUint16(packet.CalculatePseudoHdrIPv4UDPCksum(l3, l4))
+			pkt.SetTXIPv4UDPOLFlags(common.EtherLen, common.IPv4MinLen)
 		} else {
 			l3.HdrChecksum = packet.SwapBytesUint16(packet.CalculateIPv4Checksum(l3))
 			l4.DgramCksum = packet.SwapBytesUint16(packet.CalculateIPv4UDPChecksum(l3, l4,
@@ -24,12 +25,13 @@ func setIPv4UDPChecksum(l3 *packet.IPv4Hdr, l4 *packet.UDPHdr,
 	}
 }
 
-func setIPv4TCPChecksum(l3 *packet.IPv4Hdr, l4 *packet.TCPHdr,
+func setIPv4TCPChecksum(pkt *packet.Packet, l3 *packet.IPv4Hdr, l4 *packet.TCPHdr,
 	CalculateChecksum, HWTXChecksum bool) {
 	if CalculateChecksum {
 		if HWTXChecksum {
 			l3.HdrChecksum = 0
 			l4.Cksum = packet.SwapBytesUint16(packet.CalculatePseudoHdrIPv4TCPCksum(l3))
+			pkt.SetTXIPv4TCPOLFlags(common.EtherLen, common.IPv4MinLen)
 		} else {
 			l3.HdrChecksum = packet.SwapBytesUint16(packet.CalculateIPv4Checksum(l3))
 			l4.Cksum = packet.SwapBytesUint16(packet.CalculateIPv4TCPChecksum(l3, l4,
@@ -38,9 +40,15 @@ func setIPv4TCPChecksum(l3 *packet.IPv4Hdr, l4 *packet.TCPHdr,
 	}
 }
 
-func setIPv4ICMPChecksum(l3 *packet.IPv4Hdr, l4 *packet.ICMPHdr, CalculateChecksum, HWTXChecksum bool) {
+func setIPv4ICMPChecksum(pkt *packet.Packet, l3 *packet.IPv4Hdr, l4 *packet.ICMPHdr,
+	CalculateChecksum, HWTXChecksum bool) {
 	if CalculateChecksum {
-		l3.HdrChecksum = packet.SwapBytesUint16(packet.CalculateIPv4Checksum(l3))
+		if HWTXChecksum {
+			l3.HdrChecksum = 0
+			pkt.SetTXIPv4OLFlags(common.EtherLen, common.IPv4MinLen)
+		} else {
+			l3.HdrChecksum = packet.SwapBytesUint16(packet.CalculateIPv4Checksum(l3))
+		}
 		l4.Cksum = 0
 		l4.Cksum = packet.SwapBytesUint16(packet.CalculateIPv4ICMPChecksum(l3, l4))
 	}

--- a/examples/nat/main/config2ports.json
+++ b/examples/nat/main/config2ports.json
@@ -4,24 +4,24 @@
             "private-port": {
                 "index": 2,
                 "dst_mac": "3c:fd:fe:a5:4d:61",
-                "subnet": "192.168.1.1/24"
+                "subnet": "192.168.14.1/24"
             },
             "public-port": {
                 "index": 3,
                 "dst_mac": "3c:fd:fe:a5:4d:68",
-                "subnet": "10.1.1.1"
+                "subnet": "192.168.16.1"
             }
         },
         {
             "private-port": {
                 "index": 4,
                 "dst_mac": "3c:fd:fe:a5:4d:63",
-                "subnet": "192.168.1.1/24"
+                "subnet": "192.168.24.1/24"
             },
             "public-port": {
                 "index": 5,
                 "dst_mac": "3c:fd:fe:a5:4d:6a",
-                "subnet": "10.1.1.1"
+                "subnet": "192.168.26.1"
             }
         }
     ]

--- a/examples/nat/main/nat.go
+++ b/examples/nat/main/nat.go
@@ -33,8 +33,7 @@ func main() {
 
 	flow.SystemInit(&yanffconfig)
 
-	// Read MAC addresses for local ports
-	nat.InitLocalMACs()
+	// Initialize flows and necessary state
 	nat.InitFlows()
 
 	flow.SystemStart()

--- a/examples/nat/translation.go
+++ b/examples/nat/translation.go
@@ -177,13 +177,13 @@ func PublicToPrivateTranslation(pkt *packet.Packet, ctx flow.UserContext) uint {
 
 	if pktTCP != nil {
 		pktTCP.DstPort = packet.SwapBytesUint16(value.port)
-		setIPv4TCPChecksum(pktIPv4, pktTCP, CalculateChecksum, HWTXChecksum)
+		setIPv4TCPChecksum(pkt, pktIPv4, pktTCP, CalculateChecksum, HWTXChecksum)
 	} else if pktUDP != nil {
 		pktUDP.DstPort = packet.SwapBytesUint16(value.port)
-		setIPv4UDPChecksum(pktIPv4, pktUDP, CalculateChecksum, HWTXChecksum)
+		setIPv4UDPChecksum(pkt, pktIPv4, pktUDP, CalculateChecksum, HWTXChecksum)
 	} else {
 		pktICMP.Identifier = packet.SwapBytesUint16(value.port)
-		setIPv4ICMPChecksum(pktIPv4, pktICMP, CalculateChecksum, HWTXChecksum)
+		setIPv4ICMPChecksum(pkt, pktIPv4, pktICMP, CalculateChecksum, HWTXChecksum)
 	}
 
 	dumpOutput(pkt, pi.index)
@@ -272,13 +272,13 @@ func PrivateToPublicTranslation(pkt *packet.Packet, ctx flow.UserContext) uint {
 
 	if pktTCP != nil {
 		pktTCP.SrcPort = packet.SwapBytesUint16(value.port)
-		setIPv4TCPChecksum(pktIPv4, pktTCP, CalculateChecksum, HWTXChecksum)
+		setIPv4TCPChecksum(pkt, pktIPv4, pktTCP, CalculateChecksum, HWTXChecksum)
 	} else if pktUDP != nil {
 		pktUDP.SrcPort = packet.SwapBytesUint16(value.port)
-		setIPv4UDPChecksum(pktIPv4, pktUDP, CalculateChecksum, HWTXChecksum)
+		setIPv4UDPChecksum(pkt, pktIPv4, pktUDP, CalculateChecksum, HWTXChecksum)
 	} else {
 		pktICMP.Identifier = packet.SwapBytesUint16(value.port)
-		setIPv4ICMPChecksum(pktIPv4, pktICMP, CalculateChecksum, HWTXChecksum)
+		setIPv4ICMPChecksum(pkt, pktIPv4, pktICMP, CalculateChecksum, HWTXChecksum)
 	}
 
 	dumpOutput(pkt, pi.index)
@@ -381,6 +381,6 @@ func (port *ipv4Port) handleICMP(pkt *packet.Packet) uint {
 	swapAddrIPv4(pkt)
 	icmp.Type = common.ICMPTypeEchoResponse
 	icmp.Cksum = 0
-	setIPv4ICMPChecksum(ipv4, icmp, CalculateChecksum, HWTXChecksum)
+	setIPv4ICMPChecksum(pkt, ipv4, icmp, CalculateChecksum, HWTXChecksum)
 	return flowBack
 }

--- a/low/low.go
+++ b/low/low.go
@@ -137,7 +137,7 @@ func TrimMbuf(m *Mbuf, length uint) bool {
 }
 
 // SetTXIPv4OLFlags sets mbuf flags for IPv4 header
-// checksum calculation offloading.
+// checksum calculation hardware offloading.
 func SetTXIPv4OLFlags(mb *Mbuf, l2len, l3len uint32) {
 	// PKT_TX_IP_CKSUM | PKT_TX_IPV4
 	mb.ol_flags = (1 << 54) | (1 << 55)
@@ -152,7 +152,7 @@ func SetTXIPv4OLFlags(mb *Mbuf, l2len, l3len uint32) {
 }
 
 // SetTXIPv4UDPOLFlags sets mbuf flags for IPv4 and UDP
-// headers checksum calculation offloading.
+// headers checksum calculation hardware offloading.
 func SetTXIPv4UDPOLFlags(mb *Mbuf, l2len, l3len uint32) {
 	// PKT_TX_UDP_CKSUM | PKT_TX_IP_CKSUM | PKT_TX_IPV4
 	mb.ol_flags = (3 << 52) | (1 << 54) | (1 << 55)
@@ -167,7 +167,7 @@ func SetTXIPv4UDPOLFlags(mb *Mbuf, l2len, l3len uint32) {
 }
 
 // SetTXIPv4TCPOLFlags sets mbuf flags for IPv4 and TCP
-// headers checksum calculation offloading.
+// headers checksum calculation hardware offloading.
 func SetTXIPv4TCPOLFlags(mb *Mbuf, l2len, l3len uint32) {
 	// PKT_TX_TCP_CKSUM | PKT_TX_IP_CKSUM | PKT_TX_IPV4
 	mb.ol_flags = (1 << 52) | (1 << 54) | (1 << 55)
@@ -182,7 +182,7 @@ func SetTXIPv4TCPOLFlags(mb *Mbuf, l2len, l3len uint32) {
 }
 
 // SetTXIPv6UDPOLFlags sets mbuf flags for IPv6 UDP header
-// checksum calculation offloading.
+// checksum calculation hardware offloading.
 func SetTXIPv6UDPOLFlags(mb *Mbuf, l2len, l3len uint32) {
 	// PKT_TX_UDP_CKSUM | PKT_TX_IPV6
 	mb.ol_flags = (3 << 52) | (1 << 56)
@@ -197,7 +197,7 @@ func SetTXIPv6UDPOLFlags(mb *Mbuf, l2len, l3len uint32) {
 }
 
 // SetTXIPv6TCPOLFlags sets mbuf flags for IPv6 TCP
-// header checksum calculation offloading.
+// header checksum calculation hardware offloading.
 func SetTXIPv6TCPOLFlags(mb *Mbuf, l2len, l3len uint32) {
 	// PKT_TX_TCP_CKSUM | PKT_TX_IPV4
 	mb.ol_flags = (1 << 52) | (1 << 56)

--- a/packet/packet.go
+++ b/packet/packet.go
@@ -666,7 +666,7 @@ func InitEmptyIPv6ICMPPacket(packet *Packet, plSize uint) bool {
 }
 
 // SetHWCksumOLFlags sets hardware offloading flags to packet
-func SetHWCksumOLFlags(packet *Packet) {
+func (packet *Packet) SetHWCksumOLFlags() {
 	ipv4, ipv6 := packet.ParseAllKnownL3()
 	if ipv4 != nil {
 		packet.GetIPv4().HdrChecksum = 0
@@ -684,6 +684,36 @@ func SetHWCksumOLFlags(packet *Packet) {
 			low.SetTXIPv6UDPOLFlags(packet.CMbuf, EtherLen, IPv6Len)
 		}
 	}
+}
+
+// SetTXIPv4OLFlags sets mbuf flags for IPv4 header checksum
+// calculation offloading.
+func (packet *Packet) SetTXIPv4OLFlags(l2len, l3len uint32) {
+	low.SetTXIPv4OLFlags(packet.CMbuf, l2len, l3len)
+}
+
+// SetTXIPv4UDPOLFlags sets mbuf flags for IPv4 and UDP headers
+// checksum calculation hardware offloading.
+func (packet *Packet) SetTXIPv4UDPOLFlags(l2len, l3len uint32) {
+	low.SetTXIPv4UDPOLFlags(packet.CMbuf, l2len, l3len)
+}
+
+// SetTXIPv4TCPOLFlags sets mbuf flags for IPv4 and TCP headers
+// checksum calculation hardware offloading.
+func (packet *Packet) SetTXIPv4TCPOLFlags(l2len, l3len uint32) {
+	low.SetTXIPv4TCPOLFlags(packet.CMbuf, l2len, l3len)
+}
+
+// SetTXIPv6UDPOLFlags sets mbuf flags for IPv6 UDP header checksum
+// calculation hardware offloading.
+func (packet *Packet) SetTXIPv6TCPOLFlags(l2len, l3len uint32) {
+	low.SetTXIPv6TCPOLFlags(packet.CMbuf, l2len, l3len)
+}
+
+// SetTXIPv6TCPOLFlags sets mbuf flags for IPv6 TCP header checksum
+// calculation hardware offloading.
+func (packet *Packet) SetTXIPv6UDPOLFlags(l2len, l3len uint32) {
+	low.SetTXIPv6UDPOLFlags(packet.CMbuf, l2len, l3len)
 }
 
 // SwapBytesUint16 swaps uint16 in Little Endian and Big Endian

--- a/test/stability/test_cksum/part2.go
+++ b/test/stability/test_cksum/part2.go
@@ -65,7 +65,7 @@ func fixPacket(pkt *packet.Packet, context flow.UserContext) {
 
 	if hwol {
 		packet.SetPseudoHdrChecksum(pkt)
-		packet.SetHWCksumOLFlags(pkt)
+		pkt.SetHWCksumOLFlags()
 	} else {
 		testCommon.CalculateChecksum(pkt)
 	}


### PR DESCRIPTION
This allows parallel mutex free work of multiple port pairs on the
same NAT. Also code is more object oriented now.

Second commit fixes HW checksum calculation.