### PR TITLE
Add support for a custom CPU list

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -1,0 +1,10 @@
+# Copyright 2017 Intel Corporation.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+PATH_TO_MK = ../mk
+include $(PATH_TO_MK)/include.mk
+
+.PHONY: testing
+testing:
+	go test

--- a/common/common.go
+++ b/common/common.go
@@ -7,9 +7,12 @@
 package common
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
+	"runtime"
+	"strconv"
 )
 
 // Length of addresses.
@@ -153,4 +156,84 @@ func GetDPDKLogLevel() string {
 	default:
 		return "8"
 	}
+}
+
+// GetDefaultCPUs returns default core list {0, 1, ..., GOMAXPROCS-1}
+func GetDefaultCPUs(cpuNumber uint) []uint {
+	cpus := make([]uint, cpuNumber, cpuNumber)
+	for i := uint(0); i < cpuNumber; i++ {
+		cpus[i] = i
+	}
+	return cpus
+}
+
+var (
+	// ErrMaxCPUExceed is error in case requested CPU exceeds maximum cores number on machine
+	ErrMaxCPUExceed = errors.New("Requested cpu exceeds maximum cores number on machine")
+)
+
+// ParseCPUs parses cpu list string into array of cpu numbers
+// and truncate the list according to given coresNumber (GOMAXPROCS)
+func ParseCPUs(s string, coresNumber uint) ([]uint, error) {
+	var startRange, k int
+	nums := make([]uint, 0, 256)
+	if s == "" {
+		return nums, nil
+	}
+	startRange = -1
+	var err error
+	for i, j := 0, 0; i <= len(s); i++ {
+		if i != len(s) && s[i] == '-' {
+			startRange, err = strconv.Atoi(s[j:i])
+			if err != nil {
+				return nums, err
+			}
+			j = i + 1
+		}
+
+		if i == len(s) || s[i] == ',' {
+			r, err := strconv.Atoi(s[j:i])
+			if err != nil {
+				return nums, err
+			}
+			if startRange != -1 {
+				for k = startRange; k <= r; k++ {
+					nums = append(nums, uint(k))
+				}
+				startRange = -1
+			} else {
+				nums = append(nums, uint(r))
+			}
+			if i == len(s) {
+				break
+			}
+			j = i + 1
+		}
+	}
+
+	nums = removeDuplicates(nums)
+
+	numCPU := uint(runtime.NumCPU())
+	for _, cpu := range nums {
+		if cpu >= numCPU {
+			return []uint{}, ErrMaxCPUExceed
+		}
+	}
+	if len(nums) > int(coresNumber) {
+		return nums[:coresNumber], nil
+	}
+
+	return nums, nil
+}
+
+func removeDuplicates(array []uint) []uint {
+	result := []uint{}
+	seen := map[uint]bool{}
+	for _, val := range array {
+		if _, ok := seen[val]; !ok {
+			result = append(result, val)
+			seen[val] = true
+		}
+	}
+	return result
 }

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -1,0 +1,49 @@
+package common_test
+
+import (
+	"github.com/intel-go/yanff/common"
+	"reflect"
+	"testing"
+)
+
+const (
+	BigCPUNum   = 40
+	SmallCPUNum = 3
+)
+
+var cpuParseTests = []struct {
+	line        string // input
+	cpuNum      uint   // max number of cpus
+	expected    []uint // expected result
+	expectedErr error
+}{
+	{"", BigCPUNum, []uint{}, nil},
+	{"1-5", BigCPUNum, []uint{1, 2, 3, 4, 5}, nil},
+	{"18-21", BigCPUNum, []uint{18, 19, 20, 21}, nil},
+	{"11,12,450", BigCPUNum, []uint{}, common.ErrMaxCPUExceed},
+	{"1,10-13,9", BigCPUNum, []uint{1, 10, 11, 12, 13, 9}, nil},
+	{"10-14,13-15", BigCPUNum, []uint{10, 11, 12, 13, 14, 15}, nil},
+	{"10-14,11-12", BigCPUNum, []uint{10, 11, 12, 13, 14}, nil},
+	{"", SmallCPUNum, []uint{}, nil},
+	{"1-5", SmallCPUNum, []uint{1, 2, 3}, nil},
+	{"18-21", SmallCPUNum, []uint{18, 19, 20}, nil},
+	{"11,12,450", SmallCPUNum, []uint{}, common.ErrMaxCPUExceed},
+	{"1,10-13,9", SmallCPUNum, []uint{1, 10, 11}, nil},
+	{"10-14,13-15", SmallCPUNum, []uint{10, 11, 12}, nil},
+	{"10-14,11-12", SmallCPUNum, []uint{10, 11, 12}, nil},
+}
+
+// TestParseCPUs require minumum 22 cores to pass without error.
+// If machine has less cores, test fail with ErrMaxCPUExceed error
+func TestParseCPUs(t *testing.T) {
+	for _, tt := range cpuParseTests {
+		actual, err := common.ParseCPUs(tt.line, tt.cpuNum)
+		if err != tt.expectedErr {
+			t.Errorf("ParseCpuList(\"%s\",%d): unexpected error: %v", tt.line, tt.cpuNum, err)
+			continue
+		}
+		if !reflect.DeepEqual(actual, tt.expected) {
+			t.Errorf("ParseCpuList(\"%s\",%d): expected %v, actual %v", tt.line, tt.cpuNum, tt.expected, actual)
+		}
+	}
+}

--- a/examples/Firewall.go
+++ b/examples/Firewall.go
@@ -26,7 +26,7 @@ func main() {
 
 	// Initialize YANFF library at 8 cores by default
 	config := flow.Config{
-		CPUCoresNumber: 8,
+		CPUList: "0-7",
 	}
 	flow.SystemInit(&config)
 

--- a/examples/Forwarding.go
+++ b/examples/Forwarding.go
@@ -16,7 +16,7 @@ var l3Rules *rules.L3Rules
 func main() {
 	// Initialize YANFF library at 16 cores by default
 	config := flow.Config{
-		CPUCoresNumber: 16,
+		CPUList: "0-15",
 	}
 	flow.SystemInit(&config)
 

--- a/examples/clonable_pcap_dumper.go
+++ b/examples/clonable_pcap_dumper.go
@@ -27,7 +27,7 @@ func main() {
 
 	// Initialize YANFF library at 10 available cores
 	config := flow.Config{
-		CPUCoresNumber: 10,
+		CPUList: "0-9",
 	}
 	flow.SystemInit(&config)
 

--- a/examples/demo.go
+++ b/examples/demo.go
@@ -32,7 +32,7 @@ func main() {
 
 	// Initialize YANFF library at 16 cores by default
 	config := flow.Config{
-		CPUCoresNumber: 16,
+		CPUList: "0-15",
 	}
 	flow.SystemInit(&config)
 

--- a/examples/dump.go
+++ b/examples/dump.go
@@ -25,7 +25,7 @@ func main() {
 
 	// Initialize YANFF library at 10 available cores
 	config := flow.Config{
-		CPUCoresNumber: 10,
+		CPUList: "0-9",
 	}
 	flow.SystemInit(&config)
 

--- a/examples/kni.go
+++ b/examples/kni.go
@@ -13,8 +13,8 @@ import "github.com/intel-go/yanff/flow"
 func main() {
 	config := flow.Config{
 		// Is required for KNI
-		NeedKNI:        true,
-		CPUCoresNumber: 8,
+		NeedKNI: true,
+		CPUList: "0-7",
 	}
 
 	flow.SystemInit(&config)

--- a/examples/nat/main/nat.go
+++ b/examples/nat/main/nat.go
@@ -13,7 +13,7 @@ import (
 
 func main() {
 	// Parse arguments
-	cores := flag.Uint("cores", 44, "Specify number of CPU cores to use")
+	cores := flag.String("cores", "0-43", "Specify CPU cores to use")
 	configFile := flag.String("config", "config.json", "Specify config file name")
 	flag.BoolVar(&nat.CalculateChecksum, "csum", false, "Specify whether to calculate checksums in modified packets")
 	flag.BoolVar(&nat.HWTXChecksum, "hwcsum", false, "Specify whether to use hardware offloading for checksums calculation (requires -csum)")
@@ -27,8 +27,8 @@ func main() {
 
 	// Init YANFF system at 16 available cores
 	yanffconfig := flow.Config{
-		CPUCoresNumber: *cores,
-		HWTXChecksum:   nat.HWTXChecksum,
+		CPUList:      *cores,
+		HWTXChecksum: nat.HWTXChecksum,
 	}
 
 	flow.SystemInit(&yanffconfig)

--- a/test/localTesting/pktgen/generate.go
+++ b/test/localTesting/pktgen/generate.go
@@ -49,7 +49,7 @@ func main() {
 
 	// Init YANFF system at 16 available cores
 	config := flow.Config{
-		CPUCoresNumber: 16,
+		CPUList: "0-15",
 	}
 	flow.SystemInit(&config)
 

--- a/test/performance/ipsec.go
+++ b/test/performance/ipsec.go
@@ -22,7 +22,7 @@ func main() {
 	flag.Parse()
 
 	config := flow.Config{
-		CPUCoresNumber:   32,
+		CPUList:          "0-31",
 		DisableScheduler: noscheduler,
 	}
 	flow.SystemInit(&config)

--- a/test/performance/latency/latency-part1.go
+++ b/test/performance/latency/latency-part1.go
@@ -95,7 +95,7 @@ func main() {
 
 	// Initialize YANFF library at 30 available cores
 	config := flow.Config{
-		CPUCoresNumber: 30,
+		CPUList: "0-29",
 	}
 	flow.SystemInit(&config)
 	payloadSize = packetSize - servDataSize

--- a/test/performance/latency/latency-stub.go
+++ b/test/performance/latency/latency-stub.go
@@ -12,18 +12,18 @@ import (
 var (
 	outport uint
 	inport  uint
-	cores   uint
+	cores   string
 )
 
 // Main function for constructing packet processing graph.
 func main() {
 	flag.UintVar(&outport, "outport", 1, "port for sender")
 	flag.UintVar(&inport, "inport", 0, "port for receiver")
-	flag.UintVar(&cores, "cores", 16, "Specifies number of CPU cores to be used by YANFF library")
+	flag.StringVar(&cores, "cores", "0-15", "Specifies CPU cores to be used by YANFF library")
 
-	// Initialize YANFF library at requested number of cores.
+	// Initialize YANFF library at requested cores.
 	config := flow.Config{
-		CPUCoresNumber: cores,
+		CPUList: cores,
 	}
 	flow.SystemInit(&config)
 

--- a/test/performance/perf_light.go
+++ b/test/performance/perf_light.go
@@ -30,7 +30,7 @@ func main() {
 
 	// Initialize YANFF library at 15 cores by default
 	config := flow.Config{
-		CPUCoresNumber:   15,
+		CPUList:          "0-14",
 		DisableScheduler: noscheduler,
 	}
 	flow.SystemInit(&config)

--- a/test/performance/perf_main.go
+++ b/test/performance/perf_main.go
@@ -33,7 +33,7 @@ func main() {
 
 	// Initialize YANFF library at 35 cores by default
 	config := flow.Config{
-		CPUCoresNumber:   35,
+		CPUList:          "0-34",
 		DisableScheduler: noscheduler,
 	}
 	flow.SystemInit(&config)

--- a/test/performance/perf_seq.go
+++ b/test/performance/perf_seq.go
@@ -32,7 +32,7 @@ func main() {
 
 	// Initialize YANFF library at 35 cores by default
 	config := flow.Config{
-		CPUCoresNumber:   35,
+		CPUList:          "0-34",
 		DisableScheduler: noscheduler,
 	}
 	flow.SystemInit(&config)

--- a/test/performance/sendback.go
+++ b/test/performance/sendback.go
@@ -8,19 +8,20 @@ import "github.com/intel-go/yanff/flow"
 
 import "flag"
 
-var inport, outport, cores uint
+var inport, outport uint
+var cores string
 
 // This is a test for pure send/receive performance measurements. No
 // other functions used here.
 func main() {
 	flag.UintVar(&inport, "inport", 0, "Input port number")
 	flag.UintVar(&outport, "outport", 0, "Output port number")
-	flag.UintVar(&cores, "cores", 16, "Specifies number of CPU cores to be used by YANFF library")
+	flag.StringVar(&cores, "cores", "0-15", "Specifies CPU cores to be used by YANFF library")
 	flag.Parse()
 
 	// Initialize YANFF library to use specified number of CPU cores
 	config := flow.Config{
-		CPUCoresNumber: cores,
+		CPUList: cores,
 	}
 	flow.SystemInit(&config)
 

--- a/test/stability/test1/part1.go
+++ b/test/stability/test1/part1.go
@@ -62,7 +62,7 @@ func main() {
 
 	// Init YANFF system at 16 available cores
 	config := flow.Config{
-		CPUCoresNumber: 16,
+		CPUList: "0-15",
 	}
 	flow.SystemInit(&config)
 

--- a/test/stability/test1/part2.go
+++ b/test/stability/test1/part2.go
@@ -33,7 +33,7 @@ func main() {
 
 	// Init YANFF system at 16 available cores.
 	config := flow.Config{
-		CPUCoresNumber: 16,
+		CPUList: "0-15",
 	}
 	flow.SystemInit(&config)
 

--- a/test/stability/test_cksum/part1.go
+++ b/test/stability/test_cksum/part1.go
@@ -84,8 +84,8 @@ func main() {
 
 	// Init YANFF system at 16 available cores
 	config := flow.Config{
-		CPUCoresNumber: 16,
-		HWTXChecksum:   hwol,
+		CPUList:      "0-15",
+		HWTXChecksum: hwol,
 	}
 	flow.SystemInit(&config)
 

--- a/test/stability/test_cksum/part2.go
+++ b/test/stability/test_cksum/part2.go
@@ -27,8 +27,8 @@ func main() {
 
 	// Init YANFF system
 	config := flow.Config{
-		CPUCoresNumber: 16,
-		HWTXChecksum:   hwol,
+		CPUList:      "0-15",
+		HWTXChecksum: hwol,
 	}
 	flow.SystemInit(&config)
 

--- a/test/stability/test_handle2/test-handle2-part1.go
+++ b/test/stability/test_handle2/test-handle2-part1.go
@@ -66,7 +66,7 @@ func main() {
 
 	// Init YANFF system at 16 available cores.
 	config := flow.Config{
-		CPUCoresNumber: 16,
+		CPUList: "0-15",
 	}
 	flow.SystemInit(&config)
 

--- a/test/stability/test_handle2/test-handle2-part2.go
+++ b/test/stability/test_handle2/test-handle2-part2.go
@@ -26,7 +26,7 @@ func main() {
 
 	// Init YANFF system at 16 available cores.
 	config := flow.Config{
-		CPUCoresNumber: 16,
+		CPUList: "0-15",
 	}
 	flow.SystemInit(&config)
 

--- a/test/stability/test_merge/test-merge-part1.go
+++ b/test/stability/test_merge/test-merge-part1.go
@@ -76,7 +76,7 @@ func main() {
 	flag.Parse()
 
 	config := flow.Config{
-		CPUCoresNumber: 16,
+		CPUList: "0-15",
 	}
 	flow.SystemInit(&config)
 	stabilityCommon.InitCommonState(*configFile, *target)

--- a/test/stability/test_merge/test-merge-part2.go
+++ b/test/stability/test_merge/test-merge-part2.go
@@ -31,7 +31,7 @@ func main() {
 
 	// Init YANFF system at requested number of cores.
 	config := flow.Config{
-		CPUCoresNumber: 16,
+		CPUList: "0-15",
 	}
 	flow.SystemInit(&config)
 	stabilityCommon.InitCommonState(*configFile, *target)

--- a/test/stability/test_partition/test-partition-part1.go
+++ b/test/stability/test_partition/test-partition-part1.go
@@ -76,7 +76,7 @@ func main() {
 
 	// Init YANFF system at 16 available cores
 	config := flow.Config{
-		CPUCoresNumber: 16,
+		CPUList: "0-15",
 	}
 	flow.SystemInit(&config)
 	stabilityCommon.InitCommonState(*configFile, *target)

--- a/test/stability/test_partition/test-partition-part2.go
+++ b/test/stability/test_partition/test-partition-part2.go
@@ -32,7 +32,7 @@ func main() {
 
 	// Init YANFF system at 16 available cores.
 	config := flow.Config{
-		CPUCoresNumber: 16,
+		CPUList: "0-15",
 	}
 	flow.SystemInit(&config)
 	stabilityCommon.InitCommonState(*configFile, *target)

--- a/test/stability/test_separate/test-separate-part1.go
+++ b/test/stability/test_separate/test-separate-part1.go
@@ -84,7 +84,7 @@ func main() {
 
 	// Init YANFF system at 16 available cores
 	config := flow.Config{
-		CPUCoresNumber: 16,
+		CPUList: "0-15",
 	}
 	flow.SystemInit(&config)
 	stabilityCommon.InitCommonState(*configFile, *target)

--- a/test/stability/test_separate/test-separate-part2.go
+++ b/test/stability/test_separate/test-separate-part2.go
@@ -35,7 +35,7 @@ func main() {
 
 	// Init YANFF system at 16 available cores.
 	config := flow.Config{
-		CPUCoresNumber: 16,
+		CPUList: "0-15",
 	}
 	flow.SystemInit(&config)
 	stabilityCommon.InitCommonState(*configFile, *target)

--- a/test/stability/test_split/test-split-part1.go
+++ b/test/stability/test_split/test-split-part1.go
@@ -88,7 +88,7 @@ func main() {
 
 	// Init YANFF system at 20 available cores.
 	config := flow.Config{
-		CPUCoresNumber: 20,
+		CPUList: "0-19",
 	}
 	flow.SystemInit(&config)
 	stabilityCommon.InitCommonState(*configFile, *target)

--- a/test/stability/test_split/test-split-part2.go
+++ b/test/stability/test_split/test-split-part2.go
@@ -36,7 +36,7 @@ func main() {
 
 	// Init YANFF system at requested number of cores.
 	config := flow.Config{
-		CPUCoresNumber: 16,
+		CPUList: "0-15",
 	}
 	flow.SystemInit(&config)
 	stabilityCommon.InitCommonState(*configFile, *target)

--- a/test/stash/create_packet_example.go
+++ b/test/stash/create_packet_example.go
@@ -24,7 +24,7 @@ func main() {
 
 	// Initialize YANFF library at 16 available cores
 	config := flow.Config{
-		CPUCoresNumber: 16,
+		CPUList: "0-15",
 	}
 	flow.SystemInit(&config)
 

--- a/test/stash/forwardingTestL3.go
+++ b/test/stash/forwardingTestL3.go
@@ -35,7 +35,7 @@ func main() {
 
 	// Initialize YANFF library at 16 available cores
 	config := flow.Config{
-		CPUCoresNumber: 16,
+		CPUList: "0-15",
 	}
 	flow.SystemInit(&config)
 

--- a/test/stash/rw_example.go
+++ b/test/stash/rw_example.go
@@ -34,7 +34,7 @@ func main() {
 
 	// Initialize YANFF library at 16 cores by default
 	config := flow.Config{
-		CPUCoresNumber: 16,
+		CPUList: "0-15",
 	}
 	flow.SystemInit(&config)
 

--- a/test/stash/send_fixed_number.go
+++ b/test/stash/send_fixed_number.go
@@ -31,7 +31,7 @@ func main() {
 
 	// Initialize YANFF library at 16 cores by default
 	config := flow.Config{
-		CPUCoresNumber: 16,
+		CPUList: "0-15",
 	}
 	flow.SystemInit(&config)
 


### PR DESCRIPTION
Earlier scheduler allocated cores continuously starting from 0.
Now it takes list of CPUs from user in format like "1-4,5,10-14"
and truncate it up to GOMAXPROCS if needed.
Parameter CPUCoresNumber is removed, as now we have length of CPU list.