### PR TITLE
Adding ARP to ParseAllKnownL3

### DIFF
--- a/examples/dump.go
+++ b/examples/dump.go
@@ -64,13 +64,15 @@ func dumper(currentPacket *packet.Packet, context flow.UserContext) {
 	var icmp *packet.ICMPHdr
 
 	fmt.Printf("%v", currentPacket.Ether)
-	ipv4, ipv6 := currentPacket.ParseAllKnownL3()
+	ipv4, ipv6, arp := currentPacket.ParseAllKnownL3()
 	if ipv4 != nil {
 		fmt.Printf("%v", ipv4)
 		tcp, udp, icmp = currentPacket.ParseAllKnownL4ForIPv4()
 	} else if ipv6 != nil {
 		fmt.Printf("%v", ipv6)
 		tcp, udp, icmp = currentPacket.ParseAllKnownL4ForIPv6()
+	} else if arp != nil {
+		fmt.Printf("%v", arp)
 	} else {
 		fmt.Println("    Unknown L3 protocol")
 	}

--- a/packet/arp.go
+++ b/packet/arp.go
@@ -55,18 +55,6 @@ func (hdr *ARPHdr) String() string {
 		hdr.TPA[0], hdr.TPA[1], hdr.TPA[2], hdr.TPA[3])
 }
 
-// InitEmptyARPPacket initializes empty ARP packet
-func InitEmptyARPPacket(packet *Packet) bool {
-	var bufSize uint = common.EtherLen + common.ARPLen
-	if low.AppendMbuf(packet.CMbuf, bufSize) == false {
-		common.LogWarning(common.Debug, "InitEmptyARPPacket: Cannot append mbuf")
-		return false
-	}
-
-	packet.Ether.EtherType = SwapBytesUint16(common.ARPNumber)
-	return true
-}
-
 // initARPCommonData allocates ARP packet, fills ether header and
 // arp hrd, pro, hln, pln with values for ether and IPv4
 func initARPCommonData(packet *Packet) bool {

--- a/packet/packet_test.go
+++ b/packet/packet_test.go
@@ -23,7 +23,7 @@ var mempool *low.Mempool
 func init() {
 	argc, argv := low.InitDPDKArguments([]string{})
 	// burstSize=32, mbufNumber=8191, mbufCacheSize=250
-	low.InitDPDK(argc, argv, 32, 8191, 250)
+	low.InitDPDK(argc, argv, 32, 8191, 250, 0)
 	mempool = low.CreateMempool()
 }
 
@@ -285,7 +285,7 @@ func TestParseL3(t *testing.T) {
 			t.Fatal("Unable to construct mbuf")
 		}
 
-		_, _ = pkt.ParseAllKnownL3()
+		_, _, _ = pkt.ParseAllKnownL3()
 
 		if !reflect.DeepEqual(pkt.Ether, pkts[i].Ether) {
 			t.Errorf("Automatic parse all levels: packet %d: wrong Ether header:\ngot: %+v, \nwant: %+v\n\n", i, pkt.Ether, pkts[i].Ether)
@@ -310,7 +310,7 @@ func TestParseL4(t *testing.T) {
 		pkt := ExtractPacket(mb[0])
 		GeneratePacketFromByte(pkt, decoded)
 
-		ipv4, ipv6 := pkt.ParseAllKnownL3()
+		ipv4, ipv6, _ := pkt.ParseAllKnownL3()
 		if ipv4 != nil {
 			pkt.ParseAllKnownL4ForIPv4()
 		} else if ipv6 != nil {

--- a/packet/swcksum.go
+++ b/packet/swcksum.go
@@ -80,7 +80,7 @@ func CalculatePseudoHdrIPv6UDPCksum(hdr *IPv6Hdr, udp *UDPHdr) uint16 {
 // checksum for required pseudo-header and writes result to correct place. This
 // is required for checksum compute by hardware offload.
 func SetPseudoHdrChecksum(p *Packet) {
-	ipv4, ipv6 := p.ParseAllKnownL3()
+	ipv4, ipv6, _ := p.ParseAllKnownL3()
 	if ipv4 != nil {
 		p.GetIPv4().HdrChecksum = 0
 		tcp, udp, _ := p.ParseAllKnownL4ForIPv4()

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -441,7 +441,7 @@ func l4ACL(pkt *packet.Packet, L4 *l4Rules) bool {
 }
 
 func l3ACL(pkt *packet.Packet, rules *L3Rules) uint {
-	ipv4, ipv6 := pkt.ParseAllKnownL3()
+	ipv4, ipv6, _ := pkt.ParseAllKnownL3()
 	if ipv4 != nil {
 		for _, rule := range rules.ip4 {
 			if ((rule.SrcAddr ^ ipv4.SrcAddr) & rule.SrcMask) != 0 {

--- a/rules/rules_internal_test.go
+++ b/rules/rules_internal_test.go
@@ -71,7 +71,7 @@ var mempool *low.Mempool
 func init() {
 	argc, argv := low.InitDPDKArguments([]string{})
 	// burstSize=32, mbufNumber=8191, mbufCacheSize=250
-	low.InitDPDK(argc, argv, 32, 8191, 250)
+	low.InitDPDK(argc, argv, 32, 8191, 250, 0)
 	mempool = low.CreateMempool()
 }
 


### PR DESCRIPTION
Moving all VLANs to vlan.go (all used functions from it are there)
Moving InitEmptyARP to packet.go (all other general arp is there)
Fix InitDPDK in tests after previous commit