### PR TITLE
Changed debug trace to allow dumping traces into separate files

### DIFF
--- a/examples/nat/config.go
+++ b/examples/nat/config.go
@@ -17,14 +17,20 @@ import (
 	"github.com/intel-go/yanff/flow"
 )
 
+type terminationDirection uint8
+type interfaceType int
+
 const (
 	flowDrop   = 0
 	flowBack   = 1
 	flowOut    = 2
 	totalFlows = 3
 
-	debugDump = false
-	debugDrop = false
+	pri2pub terminationDirection = 0x0f
+	pub2pri terminationDirection = 0xf0
+
+	iPUBLIC  interfaceType = 0
+	iPRIVATE interfaceType = 1
 )
 
 type ipv4Subnet struct {
@@ -49,7 +55,7 @@ type ipv4Port struct {
 	Vlan          uint16     `json:"vlan-tag"`
 	SrcMACAddress macAddress
 	// ARP lookup table
-	ArpTable      sync.Map
+	ArpTable sync.Map
 }
 
 // Config for one port pair.
@@ -61,13 +67,13 @@ type portPair struct {
 	// Main lookup table which contains entries for public to private translation
 	pub2priTable []sync.Map
 	// Synchronization point for lookup table modifications
-	mutex        sync.Mutex
+	mutex sync.Mutex
 	// Map of allocated IP ports on public interface
-	portmap      [][]portMapEntry
+	portmap [][]portMapEntry
 	// Port that was allocated last
-	lastport     int
+	lastport int
 	// Maximum allowed port number
-	maxport      int
+	maxport int
 }
 
 // Config for NAT.
@@ -91,10 +97,15 @@ var (
 	HWTXChecksum bool
 
 	// Debug variables
-	fdump     []*os.File
-	dumpsync []sync.Mutex
-	fdrop     []*os.File
-	dropsync []sync.Mutex
+	debugDump = true
+	debugDrop = true
+	// Controls whether debug dump files are separate for private and
+	// public interface or both traces are dumped in the same file.
+	dumptogether = false
+	fdump        []*os.File
+	dumpsync     []sync.Mutex
+	fdrop        []*os.File
+	dropsync     []sync.Mutex
 )
 
 func (pi pairIndex) Copy() interface{} {
@@ -249,12 +260,16 @@ func InitFlows() {
 		flow.SetSender(toPublic, pp.PublicPort.Index)
 	}
 
+	asize := len(Natconfig.PortPairs)
+	if !dumptogether {
+		asize *= 2
+	}
 	if debugDump {
-		fdump = make([]*os.File, len(Natconfig.PortPairs))
-		dumpsync = make([]sync.Mutex, len(Natconfig.PortPairs))
+		fdump = make([]*os.File, asize)
+		dumpsync = make([]sync.Mutex, asize)
 	}
 	if debugDrop {
-		fdrop = make([]*os.File, len(Natconfig.PortPairs))
-		dropsync = make([]sync.Mutex, len(Natconfig.PortPairs))
+		fdrop = make([]*os.File, asize)
+		dropsync = make([]sync.Mutex, asize)
 	}
 }

--- a/examples/nat/main/config.json
+++ b/examples/nat/main/config.json
@@ -2,13 +2,13 @@
     "port-pairs": [
         {
             "private-port": {
-                "index": 0,
-                "subnet": "192.168.1.1/24"
+                "index": 2,
+                "subnet": "192.168.14.1/24"
             },
             "public-port": {
-                "index": 1,
-                "dst-mac": "3c:fd:fe:a4:d3:b1",
-                "subnet": "10.1.1.1"
+                "index": 3,
+                "dst-mac": "3c:fd:fe:a5:4d:68",
+                "subnet": "192.168.16.1"
             }
         }
     ]

--- a/examples/nat/portalloc.go
+++ b/examples/nat/portalloc.go
@@ -10,8 +10,6 @@ import (
 	"time"
 )
 
-type terminationDirection uint8
-
 const (
 	numPubAddr = 1
 
@@ -20,9 +18,6 @@ const (
 	numPorts  = portEnd - portStart
 
 	connectionTimeout time.Duration = 1 * time.Minute
-
-	pri2pub terminationDirection = 0x0f
-	pub2pri terminationDirection = 0xf0
 )
 
 func (dir terminationDirection) String() string {

--- a/examples/nat/util.go
+++ b/examples/nat/util.go
@@ -6,6 +6,7 @@ package nat
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/intel-go/yanff/packet"
@@ -27,53 +28,74 @@ func swapAddrIPv4(pkt *packet.Packet) {
 	ipv4.SrcAddr, ipv4.DstAddr = ipv4.DstAddr, ipv4.SrcAddr
 }
 
-func dumpInput(pkt *packet.Packet, index int) {
+func startTrace(name string, aindex, index int, isPrivate interfaceType) *os.File {
+	var fname string
+	if !dumptogether {
+		if isPrivate != 0 {
+			fname = fmt.Sprintf("%dpriv%s.pcap", index, name)
+		} else {
+			fname = fmt.Sprintf("%dpub%s.pcap", index, name)
+		}
+	} else {
+		fname = fmt.Sprintf("%d%s.pcap", index, name)
+	}
+
+	file, err := os.Create(fname)
+	if err != nil {
+		log.Fatal(err)
+	}
+	packet.WritePcapGlobalHdr(file)
+	return file
+}
+
+func dumpPacket(pkt *packet.Packet, index int, isPrivate interfaceType) {
 	if debugDump {
-		dumpsync[index].Lock()
-		// Dump input packet
-		if fdump[index] == nil {
-			fdump[index], _ = os.Create(fmt.Sprintf("%ddump.pcap", index))
-			packet.WritePcapGlobalHdr(fdump[index])
-			pkt.WritePcapOnePacket(fdump[index])
+		aindex := index
+		if !dumptogether {
+			aindex = index*2 + int(isPrivate)
 		}
 
-		pkt.WritePcapOnePacket(fdump[index])
-		dumpsync[index].Unlock()
+		dumpsync[aindex].Lock()
+		if fdump[aindex] == nil {
+			fdump[aindex] = startTrace("dump", aindex, index, isPrivate)
+		}
+
+		pkt.WritePcapOnePacket(fdump[aindex])
+		dumpsync[aindex].Unlock()
 	}
 }
 
-func dumpOutput(pkt *packet.Packet, index int) {
-	if debugDump {
-		dumpsync[index].Lock()
-		pkt.WritePcapOnePacket(fdump[index])
-		dumpsync[index].Unlock()
-	}
-}
-
-func dumpDrop(pkt *packet.Packet, index int) {
+func dumpDrop(pkt *packet.Packet, index int, isPrivate interfaceType) {
 	if debugDrop {
-		dropsync[index].Lock()
-		// Dump droped input packet
-		if fdrop[index] == nil {
-			fdrop[index], _ = os.Create(fmt.Sprintf("%ddrop.pcap", index))
-			packet.WritePcapGlobalHdr(fdrop[index])
-			pkt.WritePcapOnePacket(fdrop[index])
+		aindex := index
+		if !dumptogether {
+			aindex = index*2 + int(isPrivate)
 		}
-
-		pkt.WritePcapOnePacket(fdrop[index])
-		dropsync[index].Unlock()
+		dropsync[aindex].Lock()
+		if fdrop[aindex] == nil {
+			fdrop[aindex] = startTrace("drop", aindex, index, isPrivate)
+		}
+		pkt.WritePcapOnePacket(fdrop[aindex])
+		dropsync[aindex].Unlock()
 	}
 }
 
+// CloseAllDumpFiles closes all debug dump files.
 func CloseAllDumpFiles() {
-	for i := range fdump {
-		if fdump[i] != nil {
-			fdump[i].Close()
+	if debugDump {
+		debugDump = false
+		for i := range fdump {
+			if fdump[i] != nil {
+				fdump[i].Close()
+			}
 		}
 	}
-	for i := range fdrop {
-		if fdump[i] != nil {
-			fdump[i].Close()
+	if debugDrop {
+		debugDrop = false
+		for i := range fdrop {
+			if fdump[i] != nil {
+				fdump[i].Close()
+			}
 		}
 	}
 }


### PR DESCRIPTION
Files are divided by interface type private/public. Old dump method of
mixing everything into one trace file is also still possible.