### PR TITLE
Get rid of interface parameter in public flow functions

### DIFF
--- a/examples/antiddos/antiDDoS.go
+++ b/examples/antiddos/antiDDoS.go
@@ -96,7 +96,7 @@ func main() {
 
 	inputFlow, err := flow.SetReceiver(uint8(inPort))
 	CheckFatal(err)
-	CheckFatal(flow.SetHandler(inputFlow, handle, nil))
+	CheckFatal(flow.SetHandlerDrop(inputFlow, handle, nil))
 	CheckFatal(flow.SetSender(inputFlow, uint8(outPort)))
 	// Var isDdos is calculated in separate goroutine.
 	go calculateMetrics()

--- a/examples/antiddos/generatorForAntiDDoS.go
+++ b/examples/antiddos/generatorForAntiDDoS.go
@@ -80,7 +80,7 @@ func main() {
 	exampleDoneEvent = sync.NewCond(&sync.Mutex{})
 
 	// Create first packet flow
-	outputFlow, err := flow.SetGenerator(generatePacket, speed, nil)
+	outputFlow, err := flow.SetFastGenerator(generatePacket, speed, nil)
 	CheckFatal(err)
 	CheckFatal(flow.SetSender(outputFlow, uint8(outPort)))
 	inputFlow, err := flow.SetReceiver(uint8(inPort))

--- a/examples/dump.go
+++ b/examples/dump.go
@@ -52,12 +52,12 @@ func main() {
 		CheckFatal(flow.SetHandler(secondFlow, hexdumper, nil))
 	case 2:
 		// Writer closes flow
-		CheckFatal(flow.SetWriter(secondFlow, "out.pcap"))
+		CheckFatal(flow.SetSenderFile(secondFlow, "out.pcap"))
 	default:
 		CheckFatal(flow.SetHandler(secondFlow, dumper, nil))
 	}
 
-	// All cases except SetWriter require to merge partitioned packets to original flow
+	// All cases except SetSenderFile require to merge partitioned packets to original flow
 	var output *flow.Flow
 	if *dumptype == 2 {
 		output = firstFlow

--- a/examples/kni.go
+++ b/examples/kni.go
@@ -36,10 +36,9 @@ func main() {
 
 	fromEthFlow, err := flow.SetReceiver(uint8(0))
 	CheckFatal(err)
-	CheckFatal(flow.SetSender(fromEthFlow, kni))
+	CheckFatal(flow.SetSenderKNI(fromEthFlow, kni))
 
-	fromKNIFlow, err := flow.SetReceiver(kni)
-	CheckFatal(err)
+	fromKNIFlow := flow.SetReceiverKNI(kni)
 	CheckFatal(flow.SetSender(fromKNIFlow, uint8(1)))
 
 	CheckFatal(flow.SystemStart())

--- a/examples/tutorial/common.go
+++ b/examples/tutorial/common.go
@@ -17,7 +17,7 @@ var dstMac0 [common.EtherAddrLen]uint8
 var srcMac0 [common.EtherAddrLen]uint8
 var dstMac1 [common.EtherAddrLen]uint8
 var srcMac1 [common.EtherAddrLen]uint8
-var modifyPacket = []interface{}{modifyPacket0, modifyPacket1}
+var modifyPacket = []func(pkt *packet.Packet, ctx flow.UserContext){modifyPacket0, modifyPacket1}
 var direct = "direct"
 
 // readConfig function reads and parses config file

--- a/examples/tutorial/step10.go
+++ b/examples/tutorial/step10.go
@@ -40,7 +40,7 @@ func main() {
 	CheckFatal(err)
 
 	CheckFatal(flow.SetStopper(outputFlows[0]))
-	CheckFatal(flow.SetHandler(outputFlows[1], myHandler, nil))
+	CheckFatal(flow.SetVectorHandler(outputFlows[1], myHandler, nil))
 	for i := 1; i < flowN; i++ {
 		CheckFatal(flow.SetHandler(outputFlows[i], modifyPacket[i-1], nil))
 		CheckFatal(flow.SetSender(outputFlows[i], uint8(i-1)))

--- a/examples/tutorial/step11.go
+++ b/examples/tutorial/step11.go
@@ -38,7 +38,7 @@ func main() {
 	outputFlows, err := flow.SetSplitter(firstFlow, mySplitter, flowN, nil)
 	CheckFatal(err)
 	CheckFatal(flow.SetStopper(outputFlows[0]))
-	CheckFatal(flow.SetHandler(outputFlows[1], myHandler, nil))
+	CheckFatal(flow.SetVectorHandler(outputFlows[1], myHandler, nil))
 	for i := 1; i < flowN; i++ {
 		CheckFatal(flow.SetHandler(outputFlows[i], modifyPacket[i-1], nil))
 		CheckFatal(flow.SetSender(outputFlows[i], uint8(i-1)))

--- a/test/localTesting/pktgen/generate.go
+++ b/test/localTesting/pktgen/generate.go
@@ -67,9 +67,9 @@ func main() {
 	generator, err := getGenerator()
 	CheckFatal(err)
 	// Create packet flow
-	outputFlow, err := flow.SetGenerator(generator, 0, nil)
-	CheckFatal(err)
-	CheckFatal(flow.SetWriter(outputFlow, outFile))
+	outputFlow := flow.SetGenerator(generator, nil)
+
+	CheckFatal(flow.SetSenderFile(outputFlow, outFile))
 	// Start pipeline
 	go func() {
 		CheckFatal(flow.SystemStart())
@@ -215,7 +215,7 @@ func generateData(configuration interface{}) ([]uint8, error) {
 	return nil, fmt.Errorf("unknown data type")
 }
 
-func getGenerator() (interface{}, error) {
+func getGenerator() (func(*packet.Packet, flow.UserContext), error) {
 	switch l2 := (configuration.Data).(type) {
 	case parseConfig.EtherConfig:
 		switch l3 := l2.Data.(type) {

--- a/test/performance/ipsec.go
+++ b/test/performance/ipsec.go
@@ -40,8 +40,8 @@ func main() {
 
 	input, err := flow.SetReceiver(uint8(0))
 	CheckFatal(err)
-	CheckFatal(flow.SetHandler(input, encapsulation, *(new(context))))
-	CheckFatal(flow.SetHandler(input, decapsulation, *(new(context))))
+	CheckFatal(flow.SetHandlerDrop(input, encapsulation, *(new(context))))
+	CheckFatal(flow.SetHandlerDrop(input, decapsulation, *(new(context))))
 	CheckFatal(flow.SetSender(input, uint8(1)))
 
 	CheckFatal(flow.SystemStart())

--- a/test/performance/latency/latency-part1.go
+++ b/test/performance/latency/latency-part1.go
@@ -111,8 +111,7 @@ func main() {
 	payloadSize = packetSize - servDataSize
 
 	// Create packet flow
-	outputFlow, err := flow.SetGenerator(generatePackets, speed, nil)
-	CheckFatal(err)
+	outputFlow := flow.SetGenerator(generatePackets, nil)
 	outputFlow2, err := flow.SetPartitioner(outputFlow, 350, 350)
 	CheckFatal(err)
 

--- a/test/stability/test1/part1.go
+++ b/test/stability/test1/part1.go
@@ -82,7 +82,7 @@ func main() {
 	var m sync.Mutex
 	testDoneEvent = sync.NewCond(&m)
 
-	firstFlow, err := flow.SetGenerator(generatePacket, speed, nil)
+	firstFlow, err := flow.SetFastGenerator(generatePacket, speed, nil)
 	CheckFatal(err)
 
 	// Send all generated packets to the output

--- a/test/stability/test_cksum/part1.go
+++ b/test/stability/test_cksum/part1.go
@@ -144,8 +144,8 @@ func main() {
 	// High performance generator (enabled if speed != 0) is not used here, as it
 	// can send fully only number of packets N which is multiple of burst size (default 32),
 	// otherwise last N%burstSize packets are not sent, and cannot send N less than burstSize.
-	firstFlow, err := flow.SetGenerator(generatePacket, 0, nil)
-	CheckFatal(err)
+	firstFlow := flow.SetGenerator(generatePacket, nil)
+
 	// Send all generated packets to the output
 	CheckFatal(flow.SetSender(firstFlow, uint8(outport)))
 

--- a/test/stability/test_handle2/test-handle2-part1.go
+++ b/test/stability/test_handle2/test-handle2-part1.go
@@ -86,8 +86,7 @@ func main() {
 	testDoneEvent = sync.NewCond(&m)
 
 	// Create first packet flow
-	outputFlow, err := flow.SetGenerator(generatePacket, 0, nil)
-	CheckFatal(err)
+	outputFlow := flow.SetGenerator(generatePacket, nil)
 
 	CheckFatal(flow.SetSender(outputFlow, uint8(outport)))
 

--- a/test/stability/test_handle2/test-handle2-part2.go
+++ b/test/stability/test_handle2/test-handle2-part2.go
@@ -51,7 +51,7 @@ func main() {
 
 	// Handle packet flow
 	// ~33% of packets should left in flow1
-	CheckFatal(flow.SetHandler(flow1, l3Handler, nil))
+	CheckFatal(flow.SetHandlerDrop(flow1, l3Handler, nil))
 
 	// Send each flow to corresponding port. Send queues will be added automatically.
 	CheckFatal(flow.SetSender(flow1, uint8(outport)))

--- a/test/stability/test_merge/test-merge-part1.go
+++ b/test/stability/test_merge/test-merge-part1.go
@@ -97,12 +97,12 @@ func main() {
 	var m sync.Mutex
 	testDoneEvent = sync.NewCond(&m)
 
-	firstFlow, err := flow.SetGenerator(generatePacketGroup1, speed, nil)
+	firstFlow, err := flow.SetFastGenerator(generatePacketGroup1, speed, nil)
 	CheckFatal(err)
 	CheckFatal(flow.SetSender(firstFlow, uint8(outport1)))
 
 	// Create second packet flow
-	secondFlow, err := flow.SetGenerator(generatePacketGroup2, speed, nil)
+	secondFlow, err := flow.SetFastGenerator(generatePacketGroup2, speed, nil)
 	CheckFatal(err)
 	CheckFatal(flow.SetSender(secondFlow, uint8(outport2)))
 

--- a/test/stability/test_partition/test-partition-part1.go
+++ b/test/stability/test_partition/test-partition-part1.go
@@ -96,7 +96,7 @@ func main() {
 	testDoneEvent = sync.NewCond(&m)
 
 	// Create output packet flow
-	outputFlow, err := flow.SetGenerator(generatePacket, speed, nil)
+	outputFlow, err := flow.SetFastGenerator(generatePacket, speed, nil)
 	CheckFatal(err)
 	CheckFatal(flow.SetSender(outputFlow, uint8(outport)))
 

--- a/test/stability/test_separate/test-separate-part1.go
+++ b/test/stability/test_separate/test-separate-part1.go
@@ -104,7 +104,7 @@ func main() {
 	testDoneEvent = sync.NewCond(&m)
 
 	// Create packet flow
-	outputFlow, err := flow.SetGenerator(generatePacket, speed, nil)
+	outputFlow, err := flow.SetFastGenerator(generatePacket, speed, nil)
 	CheckFatal(err)
 	CheckFatal(flow.SetSender(outputFlow, uint8(outport)))
 

--- a/test/stability/test_split/test-split-part1.go
+++ b/test/stability/test_split/test-split-part1.go
@@ -109,7 +109,7 @@ func main() {
 	testDoneEvent = sync.NewCond(&m)
 
 	// Create first packet flow
-	outputFlow, err := flow.SetGenerator(generatePacket, speed, nil)
+	outputFlow, err := flow.SetFastGenerator(generatePacket, speed, nil)
 	CheckFatal(err)
 	CheckFatal(flow.SetSender(outputFlow, uint8(outport)))
 

--- a/test/stash/create_packet_example.go
+++ b/test/stash/create_packet_example.go
@@ -40,11 +40,11 @@ func main() {
 	CheckFatal(flow.SystemInit(&config))
 	// Create packets with speed at least 1000 packets/s
 	if *enablePacketFromByte == false {
-		firstFlow, err = flow.SetGenerator(generatePacket, 1000, nil)
+		firstFlow, err = flow.SetFastGenerator(generatePacket, 1000, nil)
 		CheckFatal(err)
 	} else {
 		buffer, _ = hex.DecodeString("00112233445501112131415108004500002ebffd00000406747a7f0000018009090504d2162e123456781234569050102000ffe60000")
-		firstFlow, err = flow.SetGenerator(generatePacketFromByte, 1000, nil)
+		firstFlow, err = flow.SetFastGenerator(generatePacketFromByte, 1000, nil)
 		CheckFatal(err)
 	}
 	// Send all generated packets to the output

--- a/test/stash/rw_example.go
+++ b/test/stash/rw_example.go
@@ -33,7 +33,6 @@ func CheckFatal(err error) {
 }
 
 func main() {
-	var err error
 	flag.StringVar(&inFile, "infile", "rw_example_in.pcap", "Input pcap file")
 	flag.StringVar(&outFile, "outfile", "rw_example_out.pcap", "Output pcap file")
 
@@ -53,16 +52,15 @@ func main() {
 	var f1 *flow.Flow
 	if useReader {
 		print("Enabled Read from file ", inFile, " and ")
-		f1 = flow.SetReader(inFile, int32(repcount))
+		f1 = flow.SetReceiverFile(inFile, int32(repcount))
 	} else {
 		print("Enabled Generate and ")
-		f1, err = flow.SetGenerator(generatePacket, 0, nil)
-		CheckFatal(err)
+		f1 = flow.SetGenerator(generatePacket, nil)
 	}
 
 	if useWriter {
 		println("Write to file", outFile)
-		CheckFatal(flow.SetWriter(f1, outFile))
+		CheckFatal(flow.SetSenderFile(f1, outFile))
 	} else {
 		println("Send to port", outport)
 		CheckFatal(flow.SetSender(f1, uint8(outport)))

--- a/test/stash/send_fixed_number.go
+++ b/test/stash/send_fixed_number.go
@@ -45,11 +45,11 @@ func main() {
 	}
 	CheckFatal(flow.SystemInit(&config))
 
-	// With generateOne all packets are sent.
-	f1, err := flow.SetGenerator(generatePacket, 0, nil)
-	CheckFatal(err)
-	// With generatePerf sent only multiple of burst-size.
-	// f1 := flow.SetGenerator(generatePacket, 100, nil)
+	// With generator all packets are sent.
+	f1 := flow.SetGenerator(generatePacket, nil)
+
+	// With fast generator sent only multiple of burst-size.
+	// f1 := flow.SetFastGenerator(generatePacket, 100, nil)
 	f2, err := flow.SetPartitioner(f1, 350, 350)
 	CheckFatal(err)
 


### PR DESCRIPTION
Created a bunch of functions instead:
SetReceiver -> SetReceiver, SetReceiverKNI, SetReceiverFile
SetSender -> SetSender, SetSenderKNI, SetSenderFile
SetHandler -> SetHandler, SetHandlerDrop, SetVectorHandler,
SetVectorHandlerDrop
SetGenerator-> SetGenerator, SetFastGenerator, SetVectorFastGenerator
SetSeparator -> SetSeparator, SetVectorSeparator