### PR TITLE
Refactor of CPU list handling

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -12,7 +12,6 @@ import (
 	"log"
 	"math"
 	"os"
-	"runtime"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -132,6 +131,7 @@ const (
 	PcapReadFail
 	PcapWriteFail
 	InvalidCPURangeErr
+	SetAffinityErr
 )
 
 // NFError is error type returned by yanff functions
@@ -305,7 +305,7 @@ func GetDPDKLogLevel() string {
 	}
 }
 
-// GetDefaultCPUs returns default core list {0, 1, ..., GOMAXPROCS-1}
+// GetDefaultCPUs returns default core list {0, 1, ..., NumCPU}
 func GetDefaultCPUs(cpuNumber uint) []uint {
 	cpus := make([]uint, cpuNumber, cpuNumber)
 	for i := uint(0); i < cpuNumber; i++ {
@@ -314,9 +314,17 @@ func GetDefaultCPUs(cpuNumber uint) []uint {
 	return cpus
 }
 
-// ParseCPUs parses cpu list string into array of cpu numbers
-// and truncate the list according to given coresNumber (GOMAXPROCS)
-func ParseCPUs(s string, coresNumber uint) ([]uint, error) {
+// HandleCPUs parses cpu list string into array of valid core numbers.
+// Removes duplicates
+func HandleCPUList(s string, maxcpu uint) ([]uint, error) {
+	nums, err := parseCPUs(s)
+	nums = removeDuplicates(nums)
+	nums = dropInvalidCPUs(nums, maxcpu)
+	return nums, err
+}
+
+// parseCPUs parses cpu list string into array of cpu numbers
+func parseCPUs(s string) ([]uint, error) {
 	var startRange, k int
 	nums := make([]uint, 0, 256)
 	if s == "" {
@@ -355,19 +363,6 @@ func ParseCPUs(s string, coresNumber uint) ([]uint, error) {
 			j = i + 1
 		}
 	}
-
-	nums = removeDuplicates(nums)
-
-	numCPU := uint(runtime.NumCPU())
-	for _, cpu := range nums {
-		if cpu >= numCPU {
-			return []uint{}, WrapWithNFError(nil, "requested cpu exceeds maximum cores number on machine", MaxCPUExceedErr)
-		}
-	}
-	if len(nums) > int(coresNumber) {
-		return nums[:coresNumber], nil
-	}
-
 	return nums, nil
 }
 
@@ -381,4 +376,19 @@ func removeDuplicates(array []uint) []uint {
 		}
 	}
 	return result
+}
+
+// dropInvalidCPUs validates cpu list. Takes array of cpu ids and checks it is < maxcpu on machine,
+// invalid are excluded. Returns list of valid cpu ids.
+func dropInvalidCPUs(nums []uint, maxcpu uint) []uint {
+	i := 0
+	for _, x := range nums {
+		if x < maxcpu {
+			nums[i] = x
+			i++
+		} else {
+			LogWarning(Initialization, "Requested cpu", x, "exceeds maximum cores number on machine, skip it")
+		}
+	}
+	return nums[:i]
 }

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -1,11 +1,9 @@
-package common_test
+package common
 
 import (
 	"reflect"
 	"strconv"
 	"testing"
-
-	"github.com/intel-go/yanff/common"
 )
 
 const (
@@ -13,46 +11,71 @@ const (
 	SmallCPUNum = 3
 )
 
-var maxCpuErr = common.WrapWithNFError(nil, "requested cpu exceeds maximum cores number on machine", common.MaxCPUExceedErr)
-var invalidCpuRangeErr = common.WrapWithNFError(nil, "CPU range is invalid, min should not exceed max", common.InvalidCPURangeErr)
+var maxCpuErr = WrapWithNFError(nil, "requested cpu exceeds maximum cores number on machine", MaxCPUExceedErr)
+var invalidCpuRangeErr = WrapWithNFError(nil, "CPU range is invalid, min should not exceed max", InvalidCPURangeErr)
 
 var cpuParseTests = []struct {
 	line        string // input
-	cpuNum      uint   // max number of cpus
 	expected    []uint // expected result
 	expectedErr error
 }{
-	{"", BigCPUNum, []uint{}, nil},
-	{"1-5", BigCPUNum, []uint{1, 2, 3, 4, 5}, nil},
-	{"18-21", BigCPUNum, []uint{18, 19, 20, 21}, nil},
-	{"11,12,450", BigCPUNum, []uint{}, common.GetNFError(maxCpuErr)},
-	{"1,10-13,9", BigCPUNum, []uint{1, 10, 11, 12, 13, 9}, nil},
-	{"10-14,13-15", BigCPUNum, []uint{10, 11, 12, 13, 14, 15}, nil},
-	{"10-14,11-12", BigCPUNum, []uint{10, 11, 12, 13, 14}, nil},
-	{"", SmallCPUNum, []uint{}, nil},
-	{"1-5", SmallCPUNum, []uint{1, 2, 3}, nil},
-	{"18-21", SmallCPUNum, []uint{18, 19, 20}, nil},
-	{"11,12,450", SmallCPUNum, []uint{}, common.GetNFError(maxCpuErr)},
-	{"1,10-13,9", SmallCPUNum, []uint{1, 10, 11}, nil},
-	{"10-14,13-15", SmallCPUNum, []uint{10, 11, 12}, nil},
-	{"10-14,11-12", SmallCPUNum, []uint{10, 11, 12}, nil},
-	{"1-3,6-", BigCPUNum, []uint{1, 2, 3}, &strconv.NumError{"Atoi", "", strconv.ErrSyntax}},
-	{"-1", BigCPUNum, []uint{}, &strconv.NumError{"Atoi", "", strconv.ErrSyntax}},
-	{"10-6", SmallCPUNum, []uint{}, common.GetNFError(invalidCpuRangeErr)},
-	{"1-3,10-6", SmallCPUNum, []uint{1, 2, 3}, common.GetNFError(invalidCpuRangeErr)},
+	{"", []uint{}, nil},
+	{"1-5", []uint{1, 2, 3, 4, 5}, nil},
+	{"1,10-13,9", []uint{1, 10, 11, 12, 13, 9}, nil},
+	{"10-14,13-15", []uint{10, 11, 12, 13, 14, 13, 14, 15}, nil},
+	{"1-3,6-", []uint{1, 2, 3}, &strconv.NumError{"Atoi", "", strconv.ErrSyntax}},
+	{"-1", []uint{}, &strconv.NumError{"Atoi", "", strconv.ErrSyntax}},
+	{"10-6", []uint{}, GetNFError(invalidCpuRangeErr)},
+	{"1-3,10-6", []uint{1, 2, 3}, GetNFError(invalidCpuRangeErr)},
 }
 
-// TestParseCPUs require minumum 22 cores to pass without error.
-// If machine has less cores, test fail with ErrMaxCPUExceed error
 func TestParseCPUs(t *testing.T) {
 	for _, tt := range cpuParseTests {
-		actual, err := common.ParseCPUs(tt.line, tt.cpuNum)
-		if !reflect.DeepEqual(common.GetNFError(err).Cause(), tt.expectedErr) {
-			t.Errorf("ParseCpuList(\"%s\",%d): unexpected error:\ngot: %v,\nwant: %v\n", tt.line, tt.cpuNum, err, tt.expectedErr)
+		actual, err := parseCPUs(tt.line)
+		if !reflect.DeepEqual(GetNFError(err).Cause(), tt.expectedErr) {
+			t.Errorf("ParseCpuList(\"%s\"): unexpected error:\ngot: %v,\nwant: %v\n", tt.line, err, tt.expectedErr)
 			continue
 		}
 		if !reflect.DeepEqual(actual, tt.expected) {
-			t.Errorf("ParseCpuList(\"%s\",%d): got %v, want %v", tt.line, tt.cpuNum, actual, tt.expected)
+			t.Errorf("ParseCpuList(\"%s\"): got %v, want %v", tt.line, actual, tt.expected)
+		}
+	}
+}
+
+var dropInvalidCPUsTests = []struct {
+	cpus     []uint
+	maxcpu   uint
+	expected []uint // expected valid cpu list
+}{
+	{[]uint{}, 20, []uint{}},
+	{[]uint{1, 2, 100, 1, 2, 100}, 20, []uint{1, 2, 1, 2}},
+	{[]uint{1, 2, 100, 100, 2, 100}, 20, []uint{1, 2, 2}},
+}
+
+func TestDropInvalidCPUs(t *testing.T) {
+	for _, tt := range dropInvalidCPUsTests {
+		actual := dropInvalidCPUs(tt.cpus, tt.maxcpu)
+		if !reflect.DeepEqual(actual, tt.expected) {
+			t.Errorf("DropInvalidCPUs(\"%v,%d\"): got %v, want %v", tt.cpus, tt.maxcpu, actual, tt.expected)
+		}
+	}
+}
+
+var removeDuplicatesTests = []struct {
+	cpus     []uint
+	expected []uint
+}{
+	{[]uint{}, []uint{}},
+	{[]uint{1, 2, 100, 100, 2, 100}, []uint{1, 2, 100}},
+	{[]uint{1, 2, 100, 3}, []uint{1, 2, 100, 3}},
+	{[]uint{1, 2, 1, 100, 100, 3}, []uint{1, 2, 100, 3}},
+}
+
+func TestRemoveDuplicates(t *testing.T) {
+	for _, tt := range removeDuplicatesTests {
+		actual := removeDuplicates(tt.cpus)
+		if !reflect.DeepEqual(actual, tt.expected) {
+			t.Errorf("removeDuplicates(\"%v\"): got %v, want %v", tt.cpus, actual, tt.expected)
 		}
 	}
 }
@@ -60,23 +83,23 @@ func TestParseCPUs(t *testing.T) {
 var ErrorCauseTests = []struct {
 	testError        error
 	expectedCause    error
-	expectedGetNFErr *common.NFError
-	expectedCode     common.ErrorCode
+	expectedGetNFErr *NFError
+	expectedCode     ErrorCode
 }{
 	{&strconv.NumError{"Atoi", "", strconv.ErrSyntax}, nil, nil, -1},
 
-	{common.WrapWithNFError(&strconv.NumError{"Atoi", "", strconv.ErrSyntax}, "dailed to parse cpu", common.ParseCPUListErr),
+	{WrapWithNFError(&strconv.NumError{"Atoi", "", strconv.ErrSyntax}, "dailed to parse cpu", ParseCPUListErr),
 		&strconv.NumError{"Atoi", "", strconv.ErrSyntax},
-		&(common.NFError{CauseErr: &strconv.NumError{"Atoi", "", strconv.ErrSyntax}, Message: "dailed to parse cpu", Code: common.ParseCPUListErr}),
-		common.ParseCPUListErr},
+		&(NFError{CauseErr: &strconv.NumError{"Atoi", "", strconv.ErrSyntax}, Message: "dailed to parse cpu", Code: ParseCPUListErr}),
+		ParseCPUListErr},
 
-	{common.WrapWithNFError(maxCpuErr, "dailed to parse cpu", common.ParseCPUListErr),
-		&(common.NFError{CauseErr: nil, Message: "requested cpu exceeds maximum cores number on machine", Code: common.MaxCPUExceedErr}),
-		&(common.NFError{CauseErr: maxCpuErr, Message: "dailed to parse cpu", Code: common.ParseCPUListErr}), common.ParseCPUListErr},
+	{WrapWithNFError(maxCpuErr, "dailed to parse cpu", ParseCPUListErr),
+		&(NFError{CauseErr: nil, Message: "requested cpu exceeds maximum cores number on machine", Code: MaxCPUExceedErr}),
+		&(NFError{CauseErr: maxCpuErr, Message: "dailed to parse cpu", Code: ParseCPUListErr}), ParseCPUListErr},
 
-	{common.WrapWithNFError(nil, "dailed to parse cpu", common.ParseCPUListErr),
-		&(common.NFError{CauseErr: nil, Message: "dailed to parse cpu", Code: common.ParseCPUListErr}),
-		&(common.NFError{CauseErr: nil, Message: "dailed to parse cpu", Code: common.ParseCPUListErr}), common.ParseCPUListErr},
+	{WrapWithNFError(nil, "dailed to parse cpu", ParseCPUListErr),
+		&(NFError{CauseErr: nil, Message: "dailed to parse cpu", Code: ParseCPUListErr}),
+		&(NFError{CauseErr: nil, Message: "dailed to parse cpu", Code: ParseCPUListErr}), ParseCPUListErr},
 
 	{nil, nil, nil, -1},
 }
@@ -84,16 +107,16 @@ var ErrorCauseTests = []struct {
 // TestErrorCause checks GetNFError, GetNFErrorCode, and Cause methods.
 func TestErrorCause(t *testing.T) {
 	for _, tt := range ErrorCauseTests {
-		if !reflect.DeepEqual(common.GetNFError(tt.testError), tt.expectedGetNFErr) {
-			t.Errorf("GetNFError: got: %v, want: %v\ntypes: %v, %v", common.GetNFError(tt.testError), tt.expectedGetNFErr,
-				reflect.TypeOf(common.GetNFError(tt.testError)), reflect.TypeOf(tt.expectedGetNFErr))
+		if !reflect.DeepEqual(GetNFError(tt.testError), tt.expectedGetNFErr) {
+			t.Errorf("GetNFError: got: %v, want: %v\ntypes: %v, %v", GetNFError(tt.testError), tt.expectedGetNFErr,
+				reflect.TypeOf(GetNFError(tt.testError)), reflect.TypeOf(tt.expectedGetNFErr))
 		}
-		if !reflect.DeepEqual(common.GetNFError(tt.testError).Cause(), tt.expectedCause) {
-			t.Errorf("GetNFError.Cause: got: %v, want: %v\ntypes: %v, %v", common.GetNFError(tt.testError).Cause(), tt.expectedCause,
-				reflect.TypeOf(common.GetNFError(tt.testError).Cause()), reflect.TypeOf(tt.expectedCause))
+		if !reflect.DeepEqual(GetNFError(tt.testError).Cause(), tt.expectedCause) {
+			t.Errorf("GetNFError.Cause: got: %v, want: %v\ntypes: %v, %v", GetNFError(tt.testError).Cause(), tt.expectedCause,
+				reflect.TypeOf(GetNFError(tt.testError).Cause()), reflect.TypeOf(tt.expectedCause))
 		}
-		if !reflect.DeepEqual(common.GetNFErrorCode(tt.testError), tt.expectedCode) {
-			t.Errorf("NFError code: got: %v, want: %v\n", common.GetNFError(tt.testError), tt.expectedGetNFErr)
+		if !reflect.DeepEqual(GetNFErrorCode(tt.testError), tt.expectedCode) {
+			t.Errorf("NFError code: got: %v, want: %v\n", GetNFError(tt.testError), tt.expectedGetNFErr)
 		}
 	}
 }

--- a/flow/flow.go
+++ b/flow/flow.go
@@ -354,11 +354,11 @@ type Config struct {
 // SystemInit is initialization of system. This function should be always called before graph construction.
 // Function can panic during execution.
 func SystemInit(args *Config) error {
-	CPUCoresNumber := uint(runtime.GOMAXPROCS(0))
+	CPUCoresNumber := uint(runtime.NumCPU())
 	var cpus []uint
 	var err error
 	if args.CPUList != "" {
-		if cpus, err = common.ParseCPUs(args.CPUList, CPUCoresNumber); err != nil {
+		if cpus, err = common.HandleCPUList(args.CPUList, CPUCoresNumber); err != nil {
 			return err
 		}
 	} else {
@@ -867,7 +867,9 @@ func generateOne(parameters interface{}, core uint8) {
 	gp := parameters.(*generateParameters)
 	OUT := gp.out
 	generateFunction := gp.generateFunction
-	low.SetAffinity(core)
+	if err := low.SetAffinity(core); err != nil {
+		common.LogFatal(common.Debug, "Failed to set affinity to", core, "core: ", err)
+	}
 
 	for {
 		tempPacket, err := packet.NewPacket()
@@ -1193,7 +1195,9 @@ func partition(parameters interface{}, core uint8) {
 	N := cp.N
 	M := cp.M
 
-	low.SetAffinity(core)
+	if err := low.SetAffinity(core); err != nil {
+		common.LogFatal(common.Debug, "Failed to set affinity to", core, "core: ", err)
+	}
 
 	bufsIn := make([]uintptr, burstSize)
 	bufsFirst := make([]uintptr, burstSize)


### PR DESCRIPTION
SetAffinity now returns error.
ParseCPU now does only parsing. Add DropInvalidCPUs.
Common test now does not not require many cores.